### PR TITLE
Fix no expansion after returning to previously working window

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
  - OS: [e.g. elementary OS 5.0 Juno]
- - Snippet Pixie Version [e.g. 0.9.2]
+ - Snippet Pixie Version [e.g. 0.9.3]
  - Related Application [e.g. Chrome, Firefox, Mail, Quilter]
 
 **Additional context**

--- a/data/com.github.bytepixie.snippetpixie.appdata.xml.in
+++ b/data/com.github.bytepixie.snippetpixie.appdata.xml.in
@@ -33,7 +33,7 @@
     <binary>com.github.bytepixie.snippetpixie</binary>
   </provides>
   <releases>
-    <release version="0.9.2" date="2018-12-01">
+    <release version="0.9.3" date="2018-12-01">
       <description>
         <p>Initial release</p>
       </description>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-com.github.bytepixie.snippetpixie (0.9.2) xenial; urgency=medium
+com.github.bytepixie.snippetpixie (0.9.3) xenial; urgency=medium
 
   * Initial Release.
 

--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,6 @@ Standards-Version: 3.9.3
 Package: com.github.bytepixie.snippetpixie
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}
-Description: Your expandable little snippet helper.
+Description: Your little expandable snippet helper.
  Save your often used snippets and then expand them whenever you type their abbreviation.
  For example:- "spr`" expands to "Snippet Pixie rules!"

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -238,6 +238,7 @@ namespace SnippetPixie {
             try {
                 if (parent == null) {
                     parent = Atspi.get_desktop (0);
+                    debug ("Hmmm, had to go to desktop to try and find focused control, seems suspicious.");
                 } else {
                     var app = parent.get_application ();
                     if (app.get_name () == this.application_id) {
@@ -245,7 +246,7 @@ namespace SnippetPixie {
                     }
                 }
             } catch (Error e) {
-                message ("Could not get check current app: %s", e.message);
+                message ("Could not get/check current app: %s", e.message);
                 Atspi.exit ();
                 quit ();
             }
@@ -260,27 +261,32 @@ namespace SnippetPixie {
                 quit ();
             }
 
-            for (int i = 0; i < children; i++) {
-                Atspi.Accessible child = null;
+            if (children > 0) {
+                for (int i = 0; i < children; i++) {
+                    Atspi.Accessible child = null;
 
-                try {
-                    child = parent.get_child_at_index(i);
-                } catch (Error e) {
-                    message ("Could not get child control: %s", e.message);
-                    Atspi.exit ();
-                    quit ();
-                }
+                    try {
+                        child = parent.get_child_at_index(i);
+                    } catch (Error e) {
+                        message ("Could not get child control: %s", e.message);
+                        Atspi.exit ();
+                        quit ();
+                    }
 
-                if (child.states.contains(Atspi.StateType.FOCUSED) && (child is Atspi.EditableText)) {
-                    debug ("$$$ Found focsed child control.");
-                    return child;
-                }
+                    if (child.states.contains(Atspi.StateType.FOCUSED) && (child is Atspi.EditableText)) {
+                        debug ("$$$ Found focsed child control.");
+                        return child;
+                    }
 
-                var control = get_focused_control (child);
+                    // If the child control is visible and showing it's worth looking at its children.
+                    if (child.states.contains(Atspi.StateType.VISIBLE) && child.states.contains(Atspi.StateType.SHOWING)) {
+                        var control = get_focused_control (child);
 
-                // Woo hoo, found it buried down here somewhere.
-                if (control != null) {
-                    return control;
+                        // Woo hoo, found it buried down here somewhere.
+                        if (control != null) {
+                            return control;
+                        }
+                    }
                 }
             }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -213,6 +213,11 @@ namespace SnippetPixie {
         private bool on_window_activate (Atspi.Event event) {
             debug (">>> WINDOW ACTIVATE EVENT Type ='%s', Source: '%s'", event.type, event.source.name);
 
+            if (event.source != null) {
+                event.source.clear_cache ();
+                debug ("Cleared the cache for '%s'", event.source.name);
+            }
+
             // If a window is being returned to one way or another, then check whether an editable text is already focused.
             focused_control = get_focused_control (event.source);
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -21,7 +21,7 @@
 namespace SnippetPixie {
     public class Application : Gtk.Application {
         private static Application? _app = null;
-        private string version_string = "0.9.2";
+        private string version_string = "0.9.3";
 
         private bool app_running = false;
         private bool show = true;


### PR DESCRIPTION
This (hopefully) fixes the occasional problem I've seen of expansion is working fine in an app (such as Quilter), then I switch away to something and and when I come back to Quilter expansion doesn't work any longer.

Also has massive performance boost that avoids issues with apps like Ideogram that have large arrays of controls, but most are not visible.

Resolves #14 