### PR TITLE
Autostart

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
  - OS: [e.g. elementary OS 5.0 Juno]
- - Snippet Pixie Version [e.g. 0.9.3]
+ - Snippet Pixie Version [e.g. 0.9.4]
  - Related Application [e.g. Chrome, Firefox, Mail, Quilter]
 
 **Additional context**

--- a/data/com.github.bytepixie.snippetpixie.desktop.in
+++ b/data/com.github.bytepixie.snippetpixie.desktop.in
@@ -7,8 +7,8 @@ Keywords=expand;text;snippet;
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=GTK;Utility;
-Actions=Start;Stop;
+Categories=GTK;Office;TextTools;Utility;
+Actions=Start;Stop;ToggleAutoStart;
 
 [Desktop Action Start]
 Name=Start Snippet Pixie

--- a/data/com.github.bytepixie.snippetpixie.desktop.in
+++ b/data/com.github.bytepixie.snippetpixie.desktop.in
@@ -8,7 +8,7 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Categories=GTK;Office;TextTools;Utility;
-Actions=Start;Stop;ToggleAutoStart;
+Actions=Start;Stop;
 
 [Desktop Action Start]
 Name=Start Snippet Pixie

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -438,10 +438,9 @@ namespace SnippetPixie {
             var dest_file = File.new_for_path (dest_path);
 
             if (! dest_file.query_exists ()) {
-                // By default we do not want to autostart.
-                // But we do want the Startup entry.
-                update_autostart (false);
-                return false;
+                // By default we want to autostart.
+                update_autostart (true);
+                return true;
             }
 
             var autostart = false;
@@ -468,7 +467,7 @@ namespace SnippetPixie {
 
             OptionEntry[] options = new OptionEntry[7];
             options[0] = { "show", 0, 0, OptionArg.NONE, ref show, "Show Snippet Pixie's window (default action)", null };
-            options[1] = { "start", 0, 0, OptionArg.NONE, ref start, "Start in the background", null };
+            options[1] = { "start", 0, 0, OptionArg.NONE, ref start, "Start with no window", null };
             options[2] = { "stop", 0, 0, OptionArg.NONE, ref stop, "Fully quit the application, including the background process", null };
             options[3] = { "autostart", 0, 0, OptionArg.STRING, ref autostart, "Turn auto start of Snippet Pixie on login, on, off, or show status of setting", "{on|off|status}" };
             options[4] = { "status", 0, 0, OptionArg.NONE, ref status, "Shows status of the application, exits with status 0 if running, 1 if not", null };
@@ -552,6 +551,7 @@ namespace SnippetPixie {
 
             // If we get here we're either showing the window or running the background process.
             if ( show == false || ! app_running ) {
+                get_autostart ();
                 hold ();
             }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -438,9 +438,10 @@ namespace SnippetPixie {
             var dest_file = File.new_for_path (dest_path);
 
             if (! dest_file.query_exists ()) {
-                // By default we want to autostart.
-                update_autostart (true);
-                return true;
+                // By default we do not want to autostart.
+                // But we do want the Startup entry.
+                update_autostart (false);
+                return false;
             }
 
             var autostart = false;


### PR DESCRIPTION
Resolves #5 

By default Snippet Pixie will be started on login.

This can be turned off via the Snippet Pixie entry in the Applications -> Startup section of System Settings.

There is also a new `autostart` command line option for controlling autostart.

```
$ com.github.bytepixie.snippetpixie --help
Usage:
  com.github.bytepixie.snippetpixie [OPTION…]

Options:
  --show                          Show Snippet Pixie's window (default action)
  --start                         Start with no window
  --stop                          Fully quit the application, including the background process
  --autostart={on|off|status}     Turn auto start of Snippet Pixie on login, on, off, or show status of setting
  --status                        Shows status of the application, exits with status 0 if running, 1 if not
  --version                       Display version number
  -h, --help                      Display this help
```