### PR TITLE
Cleaned up which strings should or should not be translatable.

### DIFF
--- a/po/com.github.bytepixie.snippetpixie.pot
+++ b/po/com.github.bytepixie.snippetpixie.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.bytepixie.snippetpixie\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-06 00:14+0000\n"
+"POT-Creation-Date: 2019-02-06 20:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,8 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:7
-#: data/com.github.bytepixie.snippetpixie.desktop.in:3 src/MainWindow.vala:49
-#: src/MainWindowHeader.vala:69 src/WelcomeView.vala:22
+#: data/com.github.bytepixie.snippetpixie.desktop.in:3
 msgid "Snippet Pixie"
 msgstr ""
 
@@ -39,9 +38,7 @@ msgid "For example:- \"spr`\" expands to \"Snippet Pixie rules!\""
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:20
-msgid ""
-"Added ability to export snippets to a JSON file via menu button or welcome "
-"screen."
+msgid "Added ability to export snippets to a JSON file via menu button."
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:21
@@ -52,8 +49,8 @@ msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:22
 msgid ""
-"Added ability to import snippets from an exported JSON file via menu button. "
-"Shocking! 😱"
+"Added ability to import snippets from an exported JSON file via menu button "
+"or welcome screen. Shocking! 😱"
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:23
@@ -124,6 +121,82 @@ msgstr ""
 msgid "Stop Snippet Pixie"
 msgstr ""
 
+#: src/Application.vala:474
+msgid "Show Snippet Pixie's window (default action)"
+msgstr ""
+
+#: src/Application.vala:475
+msgid "Start with no window"
+msgstr ""
+
+#: src/Application.vala:476
+msgid "Fully quit the application, including the background process"
+msgstr ""
+
+#: src/Application.vala:477
+msgid ""
+"Turn auto start of Snippet Pixie on login, on, off, or show status of setting"
+msgstr ""
+
+#: src/Application.vala:478
+msgid ""
+"Shows status of the application, exits with status 0 if running, 1 if not"
+msgstr ""
+
+#: src/Application.vala:479
+msgid "Export snippets to file"
+msgstr ""
+
+#: src/Application.vala:480
+msgid ""
+"Import snippets from file, skips snippets where abbreviation already exists"
+msgstr ""
+
+#: src/Application.vala:480
+msgid "filename"
+msgstr ""
+
+#: src/Application.vala:481
+msgid ""
+"If used in conjunction with import, existing snippets with same abbreviation "
+"are updated"
+msgstr ""
+
+#: src/Application.vala:482
+msgid "Display version number"
+msgstr ""
+
+#: src/Application.vala:483
+msgid "Display this help"
+msgstr ""
+
+#: src/Application.vala:502
+#, c-format
+msgid "error: %s\n"
+msgstr ""
+
+#: src/Application.vala:503
+#, c-format
+msgid "Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+
+#: src/Application.vala:518
+msgid "Quitting...\n"
+msgstr ""
+
+#: src/Application.vala:526
+msgid "Running.\n"
+msgstr ""
+
+#: src/Application.vala:529
+msgid "Not Running.\n"
+msgstr ""
+
+#: src/Application.vala:551
+#, c-format
+msgid "Invalid autostart value \"%s\".\n"
+msgstr ""
+
 #: src/MainWindow.vala:112 src/WelcomeView.vala:24
 msgid "Import Snippets"
 msgstr ""
@@ -192,6 +265,10 @@ msgstr ""
 msgid "Something went wrong, sorry."
 msgstr ""
 
+#: src/MainWindow.vala:189
+msgid "Copyright © Byte Pixie Limited"
+msgstr ""
+
 #: src/MainWindowHeader.vala:26
 msgid "Add snippet"
 msgstr ""
@@ -224,12 +301,12 @@ msgstr ""
 msgid "Body"
 msgstr ""
 
-#: src/WelcomeView.vala:22
-msgid "No snippets found."
+#: src/ViewStack.vala:73
+msgid "Remove Snippet"
 msgstr ""
 
-#: src/WelcomeView.vala:23
-msgid "document-new"
+#: src/WelcomeView.vala:22
+msgid "No snippets found."
 msgstr ""
 
 #: src/WelcomeView.vala:23
@@ -241,15 +318,7 @@ msgid "Create your first snippet."
 msgstr ""
 
 #: src/WelcomeView.vala:24
-msgid "document-import"
-msgstr ""
-
-#: src/WelcomeView.vala:24
 msgid "Import previously exported snippets."
-msgstr ""
-
-#: src/WelcomeView.vala:25
-msgid "help-contents"
 msgstr ""
 
 #: src/WelcomeView.vala:25

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.bytepixie.snippetpixie\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-06 00:14+0000\n"
+"POT-Creation-Date: 2019-02-06 20:33+0000\n"
 "PO-Revision-Date: 2019-02-06 00:14+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -18,8 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:7
-#: data/com.github.bytepixie.snippetpixie.desktop.in:3 src/MainWindow.vala:49
-#: src/MainWindowHeader.vala:69 src/WelcomeView.vala:22
+#: data/com.github.bytepixie.snippetpixie.desktop.in:3
 msgid "Snippet Pixie"
 msgstr ""
 
@@ -39,9 +38,7 @@ msgid "For example:- \"spr`\" expands to \"Snippet Pixie rules!\""
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:20
-msgid ""
-"Added ability to export snippets to a JSON file via menu button or welcome "
-"screen."
+msgid "Added ability to export snippets to a JSON file via menu button."
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:21
@@ -52,8 +49,8 @@ msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:22
 msgid ""
-"Added ability to import snippets from an exported JSON file via menu button. "
-"Shocking! 😱"
+"Added ability to import snippets from an exported JSON file via menu button "
+"or welcome screen. Shocking! 😱"
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:23
@@ -124,6 +121,82 @@ msgstr ""
 msgid "Stop Snippet Pixie"
 msgstr ""
 
+#: src/Application.vala:474
+msgid "Show Snippet Pixie's window (default action)"
+msgstr ""
+
+#: src/Application.vala:475
+msgid "Start with no window"
+msgstr ""
+
+#: src/Application.vala:476
+msgid "Fully quit the application, including the background process"
+msgstr ""
+
+#: src/Application.vala:477
+msgid ""
+"Turn auto start of Snippet Pixie on login, on, off, or show status of setting"
+msgstr ""
+
+#: src/Application.vala:478
+msgid ""
+"Shows status of the application, exits with status 0 if running, 1 if not"
+msgstr ""
+
+#: src/Application.vala:479
+msgid "Export snippets to file"
+msgstr ""
+
+#: src/Application.vala:480
+msgid ""
+"Import snippets from file, skips snippets where abbreviation already exists"
+msgstr ""
+
+#: src/Application.vala:480
+msgid "filename"
+msgstr ""
+
+#: src/Application.vala:481
+msgid ""
+"If used in conjunction with import, existing snippets with same abbreviation "
+"are updated"
+msgstr ""
+
+#: src/Application.vala:482
+msgid "Display version number"
+msgstr ""
+
+#: src/Application.vala:483
+msgid "Display this help"
+msgstr ""
+
+#: src/Application.vala:502
+#, c-format
+msgid "error: %s\n"
+msgstr ""
+
+#: src/Application.vala:503
+#, c-format
+msgid "Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+
+#: src/Application.vala:518
+msgid "Quitting...\n"
+msgstr ""
+
+#: src/Application.vala:526
+msgid "Running.\n"
+msgstr ""
+
+#: src/Application.vala:529
+msgid "Not Running.\n"
+msgstr ""
+
+#: src/Application.vala:551
+#, c-format
+msgid "Invalid autostart value \"%s\".\n"
+msgstr ""
+
 #: src/MainWindow.vala:112 src/WelcomeView.vala:24
 msgid "Import Snippets"
 msgstr ""
@@ -192,6 +265,10 @@ msgstr ""
 msgid "Something went wrong, sorry."
 msgstr ""
 
+#: src/MainWindow.vala:189
+msgid "Copyright © Byte Pixie Limited"
+msgstr ""
+
 #: src/MainWindowHeader.vala:26
 msgid "Add snippet"
 msgstr ""
@@ -224,12 +301,12 @@ msgstr ""
 msgid "Body"
 msgstr ""
 
-#: src/WelcomeView.vala:22
-msgid "No snippets found."
+#: src/ViewStack.vala:73
+msgid "Remove Snippet"
 msgstr ""
 
-#: src/WelcomeView.vala:23
-msgid "document-new"
+#: src/WelcomeView.vala:22
+msgid "No snippets found."
 msgstr ""
 
 #: src/WelcomeView.vala:23
@@ -241,15 +318,7 @@ msgid "Create your first snippet."
 msgstr ""
 
 #: src/WelcomeView.vala:24
-msgid "document-import"
-msgstr ""
-
-#: src/WelcomeView.vala:24
 msgid "Import previously exported snippets."
-msgstr ""
-
-#: src/WelcomeView.vala:25
-msgid "help-contents"
 msgstr ""
 
 #: src/WelcomeView.vala:25

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.bytepixie.snippetpixie\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-06 00:14+0000\n"
+"POT-Creation-Date: 2019-02-06 20:33+0000\n"
 "PO-Revision-Date: 2019-02-06 00:14+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -18,8 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:7
-#: data/com.github.bytepixie.snippetpixie.desktop.in:3 src/MainWindow.vala:49
-#: src/MainWindowHeader.vala:69 src/WelcomeView.vala:22
+#: data/com.github.bytepixie.snippetpixie.desktop.in:3
 msgid "Snippet Pixie"
 msgstr ""
 
@@ -39,9 +38,7 @@ msgid "For example:- \"spr`\" expands to \"Snippet Pixie rules!\""
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:20
-msgid ""
-"Added ability to export snippets to a JSON file via menu button or welcome "
-"screen."
+msgid "Added ability to export snippets to a JSON file via menu button."
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:21
@@ -52,8 +49,8 @@ msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:22
 msgid ""
-"Added ability to import snippets from an exported JSON file via menu button. "
-"Shocking! 😱"
+"Added ability to import snippets from an exported JSON file via menu button "
+"or welcome screen. Shocking! 😱"
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:23
@@ -124,6 +121,82 @@ msgstr ""
 msgid "Stop Snippet Pixie"
 msgstr ""
 
+#: src/Application.vala:474
+msgid "Show Snippet Pixie's window (default action)"
+msgstr ""
+
+#: src/Application.vala:475
+msgid "Start with no window"
+msgstr ""
+
+#: src/Application.vala:476
+msgid "Fully quit the application, including the background process"
+msgstr ""
+
+#: src/Application.vala:477
+msgid ""
+"Turn auto start of Snippet Pixie on login, on, off, or show status of setting"
+msgstr ""
+
+#: src/Application.vala:478
+msgid ""
+"Shows status of the application, exits with status 0 if running, 1 if not"
+msgstr ""
+
+#: src/Application.vala:479
+msgid "Export snippets to file"
+msgstr ""
+
+#: src/Application.vala:480
+msgid ""
+"Import snippets from file, skips snippets where abbreviation already exists"
+msgstr ""
+
+#: src/Application.vala:480
+msgid "filename"
+msgstr ""
+
+#: src/Application.vala:481
+msgid ""
+"If used in conjunction with import, existing snippets with same abbreviation "
+"are updated"
+msgstr ""
+
+#: src/Application.vala:482
+msgid "Display version number"
+msgstr ""
+
+#: src/Application.vala:483
+msgid "Display this help"
+msgstr ""
+
+#: src/Application.vala:502
+#, c-format
+msgid "error: %s\n"
+msgstr ""
+
+#: src/Application.vala:503
+#, c-format
+msgid "Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+
+#: src/Application.vala:518
+msgid "Quitting...\n"
+msgstr ""
+
+#: src/Application.vala:526
+msgid "Running.\n"
+msgstr ""
+
+#: src/Application.vala:529
+msgid "Not Running.\n"
+msgstr ""
+
+#: src/Application.vala:551
+#, c-format
+msgid "Invalid autostart value \"%s\".\n"
+msgstr ""
+
 #: src/MainWindow.vala:112 src/WelcomeView.vala:24
 msgid "Import Snippets"
 msgstr ""
@@ -192,6 +265,10 @@ msgstr ""
 msgid "Something went wrong, sorry."
 msgstr ""
 
+#: src/MainWindow.vala:189
+msgid "Copyright © Byte Pixie Limited"
+msgstr ""
+
 #: src/MainWindowHeader.vala:26
 msgid "Add snippet"
 msgstr ""
@@ -224,12 +301,12 @@ msgstr ""
 msgid "Body"
 msgstr ""
 
-#: src/WelcomeView.vala:22
-msgid "No snippets found."
+#: src/ViewStack.vala:73
+msgid "Remove Snippet"
 msgstr ""
 
-#: src/WelcomeView.vala:23
-msgid "document-new"
+#: src/WelcomeView.vala:22
+msgid "No snippets found."
 msgstr ""
 
 #: src/WelcomeView.vala:23
@@ -241,15 +318,7 @@ msgid "Create your first snippet."
 msgstr ""
 
 #: src/WelcomeView.vala:24
-msgid "document-import"
-msgstr ""
-
-#: src/WelcomeView.vala:24
 msgid "Import previously exported snippets."
-msgstr ""
-
-#: src/WelcomeView.vala:25
-msgid "help-contents"
 msgstr ""
 
 #: src/WelcomeView.vala:25

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.bytepixie.snippetpixie\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-06 00:14+0000\n"
+"POT-Creation-Date: 2019-02-06 20:33+0000\n"
 "PO-Revision-Date: 2019-02-06 13:09+0100\n"
 "Last-Translator: NathanBnm\n"
 "Language-Team: Français\n"
@@ -18,8 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:7
-#: data/com.github.bytepixie.snippetpixie.desktop.in:3 src/MainWindow.vala:49
-#: src/MainWindowHeader.vala:69 src/WelcomeView.vala:22
+#: data/com.github.bytepixie.snippetpixie.desktop.in:3
 msgid "Snippet Pixie"
 msgstr "Snippet Pixie"
 
@@ -42,31 +41,37 @@ msgid "For example:- \"spr`\" expands to \"Snippet Pixie rules!\""
 msgstr "Par exemple : - « spr` » s'étendra en « Snippet Pixie rules ! »"
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:20
-msgid ""
-"Added ability to export snippets to a JSON file via menu button or welcome "
-"screen."
-msgstr "Ajout de la possibilité d'exporter des raccourcis vers un fichier JSON via un bouton de menu ou depuis "
-"l'écran de bienvenue."
+#, fuzzy
+msgid "Added ability to export snippets to a JSON file via menu button."
+msgstr ""
+"Ajout de la possibilité d'exporter des raccourcis vers un fichier JSON via "
+"un bouton de menu ou depuis l'écran de bienvenue."
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:21
 msgid ""
 "Added ability to export snippets to a JSON file via `--export` or `-e` CLI "
 "options."
-msgstr "Ajouté la possibilité d'exporter des extraits vers un fichier JSON via les options en ligne de commande `--export' ou `-e'."
+msgstr ""
+"Ajouté la possibilité d'exporter des extraits vers un fichier JSON via les "
+"options en ligne de commande `--export' ou `-e'."
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:22
+#, fuzzy
 msgid ""
-"Added ability to import snippets from an exported JSON file via menu button. "
-"Shocking! 😱"
-msgstr "Ajout de la possibilité d'importer des extraits d'un fichier JSON exporté via un bouton de menu. "
-"Choquant ! 😱"
+"Added ability to import snippets from an exported JSON file via menu button "
+"or welcome screen. Shocking! 😱"
+msgstr ""
+"Ajout de la possibilité d'importer des extraits d'un fichier JSON exporté "
+"via un bouton de menu. Choquant ! 😱"
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:23
 msgid ""
 "Added ability to import snippets from an exported JSON file via `--import` "
 "or `-i` CLI options. Bet you didn't see that coming! 😉"
-msgstr "Possibilité d'importer des extraits d'un fichier JSON exporté via les options en ligne de commande `--import` "
-"ou `-i`. Je parie que vous ne l'aviez pas vu venir ! 😉"
+msgstr ""
+"Possibilité d'importer des extraits d'un fichier JSON exporté via les "
+"options en ligne de commande `--import` ou `-i`. Je parie que vous ne "
+"l'aviez pas vu venir ! 😉"
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:30
 msgid "1.0 Release!"
@@ -74,32 +79,38 @@ msgstr "Version 1.0 !"
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:31
 msgid "Added Snippet Pixie to login startup items by default."
-msgstr "Ajout de Snippet Pixie aux éléments de démarrage par défaut à la connexion."
+msgstr ""
+"Ajout de Snippet Pixie aux éléments de démarrage par défaut à la connexion."
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:32
 msgid ""
 "Added --autostart={on|off|status} option to CLI for turning autostart on, "
 "off, or getting settings status."
-msgstr "Ajout de l'option --autostart={on|off|status} aux lignes de commande pour activer, "
-"désactiver ou obtenir le statut des paramètres."
+msgstr ""
+"Ajout de l'option --autostart={on|off|status} aux lignes de commande pour "
+"activer, désactiver ou obtenir le statut des paramètres."
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:33
 msgid "Changed body field to select all text when tabbed into."
-msgstr "Changement du champ de texte pour sélectionner tout le texte lorsqu'il est affiché sous forme d'onglets."
+msgstr ""
+"Changement du champ de texte pour sélectionner tout le texte lorsqu'il est "
+"affiché sous forme d'onglets."
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:40
 msgid ""
 "Fixed crash when an application with a large number of controls was "
 "activated."
-msgstr "Correction d'un plantage lorsqu'une application avec un grand nombre de contrôles était "
-"activée."
+msgstr ""
+"Correction d'un plantage lorsqu'une application avec un grand nombre de "
+"contrôles était activée."
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:41
 msgid ""
 "Fixed problem with snippets sometimes not expanding when returning to an "
 "application."
-msgstr "Correction d'un problème avec les raccourcis qui ne se développaient pas toujours lors du retour à une "
-"application."
+msgstr ""
+"Correction d'un problème avec les raccourcis qui ne se développaient pas "
+"toujours lors du retour à une application."
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:42
 msgid "Added a splash of colour to the window header."
@@ -135,6 +146,83 @@ msgstr "Snippet Pixie"
 msgid "Stop Snippet Pixie"
 msgstr "Snippet Pixie"
 
+#: src/Application.vala:474
+msgid "Show Snippet Pixie's window (default action)"
+msgstr ""
+
+#: src/Application.vala:475
+msgid "Start with no window"
+msgstr ""
+
+#: src/Application.vala:476
+msgid "Fully quit the application, including the background process"
+msgstr ""
+
+#: src/Application.vala:477
+msgid ""
+"Turn auto start of Snippet Pixie on login, on, off, or show status of setting"
+msgstr ""
+
+#: src/Application.vala:478
+msgid ""
+"Shows status of the application, exits with status 0 if running, 1 if not"
+msgstr ""
+
+#: src/Application.vala:479
+#, fuzzy
+msgid "Export snippets to file"
+msgstr "Exporter les raccourcis"
+
+#: src/Application.vala:480
+msgid ""
+"Import snippets from file, skips snippets where abbreviation already exists"
+msgstr ""
+
+#: src/Application.vala:480
+msgid "filename"
+msgstr ""
+
+#: src/Application.vala:481
+msgid ""
+"If used in conjunction with import, existing snippets with same abbreviation "
+"are updated"
+msgstr ""
+
+#: src/Application.vala:482
+msgid "Display version number"
+msgstr ""
+
+#: src/Application.vala:483
+msgid "Display this help"
+msgstr ""
+
+#: src/Application.vala:502
+#, c-format
+msgid "error: %s\n"
+msgstr ""
+
+#: src/Application.vala:503
+#, c-format
+msgid "Run '%s --help' to see a full list of available command line options.\n"
+msgstr ""
+
+#: src/Application.vala:518
+msgid "Quitting...\n"
+msgstr ""
+
+#: src/Application.vala:526
+msgid "Running.\n"
+msgstr ""
+
+#: src/Application.vala:529
+msgid "Not Running.\n"
+msgstr ""
+
+#: src/Application.vala:551
+#, c-format
+msgid "Invalid autostart value \"%s\".\n"
+msgstr ""
+
 #: src/MainWindow.vala:112 src/WelcomeView.vala:24
 msgid "Import Snippets"
 msgstr "Importer des raccourcis"
@@ -151,8 +239,10 @@ msgstr "Écraser les raccourcis en double ?"
 msgid ""
 "If any of the snippet abbreviations about to be imported already exist, do "
 "you want to skip importing them or update the existing snippet?"
-msgstr "Si l'un des raccourcis d'abréviation sur le point d'être importé existe déjà, voulez-vous "
-"sauter l'importation ou mettre à jour le raccourci existant ?"
+msgstr ""
+"Si l'un des raccourcis d'abréviation sur le point d'être importé existe "
+"déjà, voulez-vous sauter l'importation ou mettre à jour le raccourci "
+"existant ?"
 
 #: src/MainWindow.vala:120
 msgid "Update Existing"
@@ -182,8 +272,9 @@ msgstr "Échec de l'importation du fichier sélectionné"
 msgid ""
 "Snippet Pixie can currently only import the JSON format files that it also "
 "exports."
-msgstr "Snippet Pixie ne peut actuellement importer que les fichiers au format JSON qu'il exporte "
-"également."
+msgstr ""
+"Snippet Pixie ne peut actuellement importer que les fichiers au format JSON "
+"qu'il exporte également."
 
 #: src/MainWindow.vala:161
 msgid "Export Snippets"
@@ -204,6 +295,10 @@ msgstr "Échec de l'exportation du fichier"
 #: src/MainWindow.vala:173
 msgid "Something went wrong, sorry."
 msgstr "Une erreur s'est produite, désolé."
+
+#: src/MainWindow.vala:189
+msgid "Copyright © Byte Pixie Limited"
+msgstr ""
 
 #: src/MainWindowHeader.vala:26
 msgid "Add snippet"
@@ -236,6 +331,11 @@ msgstr "Abbréviation"
 #: src/ViewStack.vala:64
 msgid "Body"
 msgstr "Corps"
+
+#: src/ViewStack.vala:73
+#, fuzzy
+msgid "Remove Snippet"
+msgstr "Raccourcis importés"
 
 #: src/WelcomeView.vala:22
 msgid "No snippets found."

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -471,16 +471,16 @@ namespace SnippetPixie {
             bool help = false;
 
             OptionEntry[] options = new OptionEntry[10];
-            options[0] = { "show", 0, 0, OptionArg.NONE, ref show, "Show Snippet Pixie's window (default action)", null };
-            options[1] = { "start", 0, 0, OptionArg.NONE, ref start, "Start with no window", null };
-            options[2] = { "stop", 0, 0, OptionArg.NONE, ref stop, "Fully quit the application, including the background process", null };
-            options[3] = { "autostart", 0, 0, OptionArg.STRING, ref autostart, "Turn auto start of Snippet Pixie on login, on, off, or show status of setting", "{on|off|status}" };
-            options[4] = { "status", 0, 0, OptionArg.NONE, ref status, "Shows status of the application, exits with status 0 if running, 1 if not", null };
-            options[5] = { "export", 'e', 0, OptionArg.FILENAME, ref export_file, "Export snippets to file", "filename" };
-            options[6] = { "import", 'i', 0, OptionArg.FILENAME, ref import_file, "Import snippets from file, skips snippets where abbreviation already exists", "filename" };
-            options[7] = { "force", 0, 0, OptionArg.NONE, ref force, "If used in conjunction with import, existing snippets with same abbreviation are updated", null };
-            options[8] = { "version", 0, 0, OptionArg.NONE, ref version, "Display version number", null };
-            options[9] = { "help", 'h', 0, OptionArg.NONE, ref help, "Display this help", null };
+            options[0] = { "show", 0, 0, OptionArg.NONE, ref show, _("Show Snippet Pixie's window (default action)"), null };
+            options[1] = { "start", 0, 0, OptionArg.NONE, ref start, _("Start with no window"), null };
+            options[2] = { "stop", 0, 0, OptionArg.NONE, ref stop, _("Fully quit the application, including the background process"), null };
+            options[3] = { "autostart", 0, 0, OptionArg.STRING, ref autostart, _("Turn auto start of Snippet Pixie on login, on, off, or show status of setting"), "{on|off|status}" };
+            options[4] = { "status", 0, 0, OptionArg.NONE, ref status, _("Shows status of the application, exits with status 0 if running, 1 if not"), null };
+            options[5] = { "export", 'e', 0, OptionArg.FILENAME, ref export_file, _("Export snippets to file"), "filename" };
+            options[6] = { "import", 'i', 0, OptionArg.FILENAME, ref import_file, _("Import snippets from file, skips snippets where abbreviation already exists"), _("filename") };
+            options[7] = { "force", 0, 0, OptionArg.NONE, ref force, _("If used in conjunction with import, existing snippets with same abbreviation are updated"), null };
+            options[8] = { "version", 0, 0, OptionArg.NONE, ref version, _("Display version number"), null };
+            options[9] = { "help", 'h', 0, OptionArg.NONE, ref help, _("Display this help"), null };
 
             // We have to make an extra copy of the array, since .parse assumes
             // that it can remove strings from the array without freeing them.
@@ -499,8 +499,8 @@ namespace SnippetPixie {
                 unowned string[] tmp = _args;
                 opt_context.parse (ref tmp);
             } catch (OptionError e) {
-                command_line.print ("error: %s\n", e.message);
-                command_line.print ("Run '%s --help' to see a full list of available command line options.\n", args[0]);
+                command_line.print (_("error: %s\n"), e.message);
+                command_line.print (_("Run '%s --help' to see a full list of available command line options.\n"), args[0]);
                 return 0;
             }
 
@@ -515,7 +515,7 @@ namespace SnippetPixie {
             }
 
             if (stop) {
-                command_line.print ("Quitting...\n");
+                command_line.print (_("Quitting...\n"));
                 var app = get_default ();
                 app.quit ();
                 return 0;
@@ -523,10 +523,10 @@ namespace SnippetPixie {
 
             if (status) {
                 if (app_running) {
-                    command_line.print ("Running.\n");
+                    command_line.print (_("Running.\n"));
                     return 0;
                 } else {
-                    command_line.print ("Not Running.\n");
+                    command_line.print (_("Not Running.\n"));
                     return 1;
                 }
             }
@@ -548,7 +548,7 @@ namespace SnippetPixie {
                     }
                     return 0;
                 default:
-                    command_line.print ("Invalid autostart value \"%s\".\n", autostart);
+                    command_line.print (_("Invalid autostart value \"%s\".\n"), autostart);
                     help = true;
                     break;
             }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -46,7 +46,7 @@ public class SnippetPixie.MainWindow : Gtk.ApplicationWindow {
             height_request: 600,
             icon_name: "com.github.bytepixie.snippetpixie",
             resizable: true,
-            title: _("Snippet Pixie"),
+            title: "Snippet Pixie",
             width_request: 800
         );
     }
@@ -186,7 +186,7 @@ public class SnippetPixie.MainWindow : Gtk.ApplicationWindow {
         dialog.authors = {"Ian M. Jones"};
 
         dialog.program_name = "Snippet Pixie";
-        dialog.copyright = "Copyright © Byte Pixie Limited";
+        dialog.copyright = _("Copyright © Byte Pixie Limited");
         dialog.logo_icon_name = Application.ID;
         dialog.version = Application.VERSION;
 

--- a/src/MainWindowHeader.vala
+++ b/src/MainWindowHeader.vala
@@ -66,7 +66,7 @@ public class SnippetPixie.MainWindowHeader : Gtk.HeaderBar {
         // pack_start (redo_button); // TODO: Add redo.
         pack_end (menu_button);
         // pack_end (search_entry); // TODO: Add search.
-        set_title (_("Snippet Pixie"));
+        set_title ("Snippet Pixie");
         show_all ();
      }
 }

--- a/src/ViewStack.vala
+++ b/src/ViewStack.vala
@@ -70,7 +70,7 @@ public class SnippetPixie.ViewStack : Gtk.Stack {
         body_entry.buffer.changed.connect (body_updated);
         snippet_form.add (body_entry);
 
-        remove_button = new Gtk.Button.with_label ("Remove Snippet");
+        remove_button = new Gtk.Button.with_label (_("Remove Snippet"));
         remove_button.hexpand = true;
         remove_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
         remove_button.clicked.connect (remove_snippet);

--- a/src/WelcomeView.vala
+++ b/src/WelcomeView.vala
@@ -19,10 +19,10 @@
 
 public class SnippetPixie.WelcomeView : Gtk.Grid {
     construct {
-        var welcome = new Granite.Widgets.Welcome ( _("Snippet Pixie"), _("No snippets found."));
-        welcome.append (_("document-new"), _("Add Snippet"), _("Create your first snippet."));
-        welcome.append (_("document-import"), _("Import Snippets"), _("Import previously exported snippets."));
-        welcome.append (_("help-contents"), _("Quick Start Guide"), _("Learn the basics of how to use Snippet Pixie."));
+        var welcome = new Granite.Widgets.Welcome ( "Snippet Pixie", _("No snippets found."));
+        welcome.append ("document-new", _("Add Snippet"), _("Create your first snippet."));
+        welcome.append ("document-import", _("Import Snippets"), _("Import previously exported snippets."));
+        welcome.append ("help-contents", _("Quick Start Guide"), _("Learn the basics of how to use Snippet Pixie."));
 
         add (welcome);
 


### PR DESCRIPTION
Resolves #28

Have left command line output other than help un-translatable for the moment as it may be used in scripts and also usually has embedded values.