### PR TITLE
Faster and more reliable text selection mode expansion.

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -514,11 +514,6 @@ namespace SnippetPixie {
                     var max = snippets_manager.max_abbr_len;
 
                     for (int pos = 1; pos <= max; pos++) {
-                        if (pos < 2) {
-                            selection.clear ();
-                            debug ("Cleared selection.");
-                        }
-
                         var grow_count = 1;
 
                         if (pos < min) {
@@ -1181,6 +1176,8 @@ namespace SnippetPixie {
                 perform_key_event ("Right", true, 0);
                 perform_key_event ("Right", false, 0);
             }
+
+            selection.clear ();
 
             Thread.yield ();
             Thread.usleep (SLEEP_INTERVAL);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -23,7 +23,7 @@ namespace SnippetPixie {
         public const string ID = "com.github.bytepixie.snippetpixie";
         public const string VERSION = "1.3.1";
 
-        private const ulong SLEEP_INTERVAL = (ulong) TimeSpan.MILLISECOND;
+        private const ulong SLEEP_INTERVAL = (ulong) TimeSpan.MILLISECOND * 10;
         private const ulong SLEEP_INTERVAL_RETRY = SLEEP_INTERVAL * 2;
         private const ulong SLEEP_INTERVAL_LONG = SLEEP_INTERVAL * 20;
 
@@ -506,6 +506,7 @@ namespace SnippetPixie {
 
                     stop_listening ();
                     release_keys ();
+                    selection.clear ();
 
                     var last_str = "";
                     var tries = 1;
@@ -525,7 +526,7 @@ namespace SnippetPixie {
                         grow_selection (grow_count, tries);
 
                         Thread.yield ();
-                        Thread.usleep (SLEEP_INTERVAL);
+                        Thread.usleep (SLEEP_INTERVAL * tries);
 
                         if (selection.wait_is_text_available () == false) {
                             debug ("Waiting a little longer for selection contents...");
@@ -1169,7 +1170,7 @@ namespace SnippetPixie {
         private void cancel_selection (string? str) {
             debug ("cancel_selection start");
 
-            perform_key_event ("<Shift>", false, 0);
+            release_keys ();
 
             // TODO: In case Clipboard access screwy, more robust check would be to see if any text is selected.
             if (str == null || str.length > 0) {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -211,8 +211,8 @@ namespace SnippetPixie {
         }
 
         private void register_listeners () {
-            lock (registered_listeners) {
-                if (registered_listeners == false) {
+            if (registered_listeners == false) {
+                lock (registered_listeners) {
 
                     debug ("Registering listeners...");
 
@@ -309,15 +309,15 @@ namespace SnippetPixie {
 
                     registered_listeners = true;
                     start_listening ();
-                } // registered_listeners false
-            } // lock registered_listeners
+                } // lock registered_listeners
+            } // registered_listeners false
         }
 
         private void deregister_listeners () {
             stop_listening ();
 
-            lock (registered_listeners) {
-                if (registered_listeners == true) {
+            if (registered_listeners == true) {
+                lock (registered_listeners) {
                     registered_listeners = false;
 
                     debug ("Deregistering listeners...");
@@ -411,8 +411,8 @@ namespace SnippetPixie {
                         Atspi.exit ();
                         quit ();
                     }
-                } // registered_listeners true
-            } // lock registered_listeners
+                } // lock registered_listeners
+            } // registered_listeners true
         }
 
         private void start_listening () {
@@ -504,7 +504,7 @@ namespace SnippetPixie {
                     checking = true;
                     debug ("Checking for abbreviation via text selection...");
 
-                    stop_listening ();
+                    deregister_listeners ();
                     release_keys ();
 
                     var last_str = "";
@@ -620,17 +620,15 @@ namespace SnippetPixie {
                         debug ("Maximum length of abbreviations ending with '%s': %d", str, max);
                     } // step back through characters
 
-                    if (expanded == false) {
+                    if (expanded == true) {
+                        // Restore clipboard from data saved before we used it.
+                        restore_clipboard ();
+                    } else {
                         cancel_selection (last_str);
                     }
 
                     checking = false;
-                    start_listening ();
-
-                    if (expanded == true) {
-                        // Restore clipboard from data saved before we used it.
-                        restore_clipboard ();
-                    }
+                    register_listeners ();
                 } // lock checking
             } // not checking
 
@@ -671,8 +669,10 @@ namespace SnippetPixie {
             //
             // TODO: Implement save/restore of all clipboard formats with switch to `wait_for_targets`, `wait_for_contents` & `set_with_data`.
             //
+            debug ("Restoring clipboard...");
 
             if (clipboard_text == null && clipboard_image == null) {
+                debug ("No clipboard saved, not restoring clipboard.");
                 return;
             }
 
@@ -717,12 +717,12 @@ namespace SnippetPixie {
                     checking = true;
                     debug ("Checking for abbreviation via editable text...");
 
-                    stop_listening ();
+                    deregister_listeners ();
 
                     if (focused_controls.has_key (wnck_app.get_pid ()) == false) {
                         debug ("Focused control missing from app map, oops!");
                         checking = false;
-                        start_listening ();
+                        register_listeners ();
                         return expanded;
                     }
 
@@ -737,7 +737,7 @@ namespace SnippetPixie {
                     } catch (Error e) {
                         message ("Could not get caret offset: %s", e.message);
                         checking = false;
-                        start_listening ();
+                        register_listeners ();
                         return expanded;
                     }
                     debug ("Caret Offset %d", caret_offset);
@@ -843,7 +843,7 @@ namespace SnippetPixie {
                     } // step back through characters
 
                     checking = false;
-                    start_listening ();
+                    register_listeners ();
                 } // lock checking
             } // not checking
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -721,6 +721,7 @@ namespace SnippetPixie {
                     var ctrl = (Atspi.Text) focused_controls.get (wnck_app.get_pid ());
                     var caret_offset = 0;
 
+                    Thread.yield ();
                     Thread.usleep (SLEEP_INTERVAL);
 
                     try {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -505,6 +505,7 @@ namespace SnippetPixie {
                     debug ("Checking for abbreviation via text selection...");
 
                     stop_listening ();
+                    release_keys ();
 
                     var last_str = "";
                     var tries = 1;
@@ -1135,6 +1136,25 @@ namespace SnippetPixie {
             }
 
             return false;
+        }
+
+        private void release_keys () {
+            debug ("release_keys start");
+
+            perform_key_event ("<Shift_L>", false, 0);
+            perform_key_event ("<Shift_R>", false, 0);
+            perform_key_event ("<Control_L>", false, 0);
+            perform_key_event ("<Control_R>", false, 0);
+            perform_key_event ("<Mod1>", false, 0);
+            perform_key_event ("<Mod2>", false, 0);
+            perform_key_event ("<Mod3>", false, 0);
+            perform_key_event ("<Mod4>", false, 0);
+            perform_key_event ("<Mod5>", false, 0);
+
+            Thread.yield ();
+            Thread.usleep (SLEEP_INTERVAL);
+
+            debug ("release_keys end");
         }
 
         private void grow_selection (int count, int tries) {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -504,7 +504,7 @@ namespace SnippetPixie {
                     checking = true;
                     debug ("Checking for abbreviation via text selection...");
 
-                    deregister_listeners ();
+                    stop_listening ();
                     release_keys ();
 
                     var last_str = "";
@@ -623,7 +623,7 @@ namespace SnippetPixie {
                     }
 
                     checking = false;
-                    register_listeners ();
+                    start_listening ();
                 } // lock checking
             } // not checking
 
@@ -712,12 +712,12 @@ namespace SnippetPixie {
                     checking = true;
                     debug ("Checking for abbreviation via editable text...");
 
-                    deregister_listeners ();
+                    stop_listening ();
 
                     if (focused_controls.has_key (wnck_app.get_pid ()) == false) {
                         debug ("Focused control missing from app map, oops!");
                         checking = false;
-                        register_listeners ();
+                        start_listening ();
                         return expanded;
                     }
 
@@ -732,7 +732,7 @@ namespace SnippetPixie {
                     } catch (Error e) {
                         message ("Could not get caret offset: %s", e.message);
                         checking = false;
-                        register_listeners ();
+                        start_listening ();
                         return expanded;
                     }
                     debug ("Caret Offset %d", caret_offset);
@@ -838,7 +838,7 @@ namespace SnippetPixie {
                     } // step back through characters
 
                     checking = false;
-                    register_listeners ();
+                    start_listening ();
                 } // lock checking
             } // not checking
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -218,14 +218,14 @@ namespace SnippetPixie {
 
                     try {
                         // Single keystrokes.
-                        Atspi.register_keystroke_listener (listener, null, 0, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, 0, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
 
                         // Shift.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.SHIFT_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.SHIFT_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Shift-Lock.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Shift + Shift-Lock.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.SHIFT_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.SHIFT_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
 
                         /*
                          * As far as I can tell, Ctrl can't be used to produce any characters.
@@ -233,13 +233,13 @@ namespace SnippetPixie {
                          * Have left code in for the time being, in case someone comes up with a good reason it's needed.
                          *
                         // Control.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.CONTROL_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.CONTROL_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Control + Shift.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.CONTROL_MASK | IBus.ModifierType.SHIFT_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.CONTROL_MASK | IBus.ModifierType.SHIFT_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Control + Shift-Lock.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.CONTROL_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.CONTROL_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Control + Shift + Shift-Lock.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.CONTROL_MASK | IBus.ModifierType.SHIFT_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.CONTROL_MASK | IBus.ModifierType.SHIFT_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                          */
 
                         /*
@@ -248,50 +248,50 @@ namespace SnippetPixie {
                          * Have left code in for the time being, in case someone comes up with a good reason it's needed.
                          *
                         // Mod1 (Alt/Meta).
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD1_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD1_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod1 + Shift.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD1_MASK | IBus.ModifierType.SHIFT_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD1_MASK | IBus.ModifierType.SHIFT_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod1 + Shift-Lock.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD1_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD1_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod1 + Shift + Shift-Lock.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD1_MASK | IBus.ModifierType.SHIFT_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD1_MASK | IBus.ModifierType.SHIFT_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                          */
 
                         // Mod2 (NumLock).
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD2_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD2_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod2 + Shift.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD2_MASK | IBus.ModifierType.SHIFT_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD2_MASK | IBus.ModifierType.SHIFT_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod2 + Shift-Lock.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD2_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD2_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod2 + Shift + Shift-Lock.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD2_MASK | IBus.ModifierType.SHIFT_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD2_MASK | IBus.ModifierType.SHIFT_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
 
                         // Mod3 (???).
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD3_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD3_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod3 + Shift.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD3_MASK | IBus.ModifierType.SHIFT_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD3_MASK | IBus.ModifierType.SHIFT_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod3 + Shift-Lock.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD3_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD3_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod3 + Shift + Shift-Lock.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD3_MASK | IBus.ModifierType.SHIFT_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD3_MASK | IBus.ModifierType.SHIFT_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
 
                         // Mod4 (Super/Menu).
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD4_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD4_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod4 + Shift.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD4_MASK | IBus.ModifierType.SHIFT_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD4_MASK | IBus.ModifierType.SHIFT_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod4 + Shift-Lock.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD4_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD4_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod4 + Shift + Shift-Lock.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD4_MASK | IBus.ModifierType.SHIFT_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD4_MASK | IBus.ModifierType.SHIFT_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
 
                         // Mod5 (ISO_Level3_Shift/Alt Gr).
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD5_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD5_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod5 + Shift.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD5_MASK | IBus.ModifierType.SHIFT_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD5_MASK | IBus.ModifierType.SHIFT_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod5 + Shift-Lock.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD5_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD5_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                         // Mod5 + Shift + Shift-Lock.
-                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD5_MASK | IBus.ModifierType.SHIFT_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type);
+                        Atspi.register_keystroke_listener (listener, null, IBus.ModifierType.MOD5_MASK | IBus.ModifierType.SHIFT_MASK | IBus.ModifierType.LOCK_MASK, Atspi.EventType.KEY_RELEASED_EVENT, listener_sync_type | Atspi.KeyListenerSyncType.NOSYNC);
                     } catch (Error e) {
                         message ("Could not register keystroke listener: %s", e.message);
                         Atspi.exit ();

--- a/src/SnippetsManager.vala
+++ b/src/SnippetsManager.vala
@@ -248,7 +248,7 @@ public class SnippetPixie.SnippetsManager : Object {
         const string query = "SELECT MIN(LENGTH(abbreviation)) FROM snippets WHERE abbreviation LIKE $ABR;";
         int ec = db.prepare_v2 (query, query.length, out stmt);
         if (ec != Sqlite.OK) {
-            warning ("Error preparing to fetch snippet: %s\n", db.errmsg ());
+            warning ("Error preparing to fetch minimum length of abbreviations with ending: %s\n", db.errmsg ());
             return min;
         }
 
@@ -268,6 +268,35 @@ public class SnippetPixie.SnippetsManager : Object {
         }
 
         return min;
+    }
+
+    public int max_length_ending_with (string abbreviation) {
+        int max = 0;
+        Sqlite.Statement stmt;
+
+        const string query = "SELECT MAX(LENGTH(abbreviation)) FROM snippets WHERE abbreviation LIKE $ABR;";
+        int ec = db.prepare_v2 (query, query.length, out stmt);
+        if (ec != Sqlite.OK) {
+            warning ("Error preparing to fetch maximum length of abbreviations with ending: %s\n", db.errmsg ());
+            return max;
+        }
+
+        int param_position = stmt.bind_parameter_index ("$ABR");
+        assert (param_position > 0);
+        stmt.bind_text (param_position, "%" + abbreviation);
+
+        while ((ec = stmt.step ()) == Sqlite.ROW) {
+            max = stmt.column_int (0);
+
+            // Return the value.
+            return max;
+        }
+        if (ec != Sqlite.DONE) {
+            warning ("Error fetching maximum length of abbreviations ending with '%s': %s\n", abbreviation, db.errmsg ());
+            return max;
+        }
+
+        return max;
     }
 
     public void add (Snippet snippet) {


### PR DESCRIPTION
Resolves #62 

However, a weird occasional 31 second lock-up still remains.
Sometimes it just stops altogether too.

~~Things to look at are potential thread conflicts, memory leaks, something else? :man_shrugging:~~

~~31 second lock-up is always when interacting with the clipboard, every now and then when trying to use `Gtk.Clipboard.wait_is_text_available ()` or `Gtk.Clipboard.wait_for_text ()` there is a significant delay. So need to either find out how I'm using those incorrectly, or find a workaround.~~

Think I've sorted it! :crossed_fingers: 