### PR TITLE
Release 1.3.2

### DIFF
--- a/data/com.github.bytepixie.snippetpixie.appdata.xml.in
+++ b/data/com.github.bytepixie.snippetpixie.appdata.xml.in
@@ -23,6 +23,16 @@
     <binary>com.github.bytepixie.snippetpixie</binary>
   </provides>
   <releases>
+    <release version="1.3.2" date="2020-05-06">
+      <description>
+        <ul>
+          <li>Improved speed of abbreviation expansion.</li>
+          <li>Fixed abbreviations randomly stopping to expand.</li>
+          <li>Fixed reliability of abbreviations being recognised.</li>
+          <li>Fixed abbreviations sometimes expanding with clipboard's contents.</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.3.1" date="2020-02-27">
       <description>
         <ul>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+com.github.bytepixie.snippetpixie (1.3.2) xenial; urgency=medium
+
+  * Improved speed of abbreviation expansion.
+  * Fixed abbreviations randomly stopping to expand.
+  * Fixed reliability of abbreviations being recognised.
+  * Fixed abbreviations sometimes expanding with clipboard's contents.
+
+ -- Byte Pixie <hello@bytepixie.com>  Wed, 06 May 2020 12:34:56 +0000
+
 com.github.bytepixie.snippetpixie (1.3.1) xenial; urgency=medium
 
   * Fixed abbreviations sometimes not expanding.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: snippetpixie
 base: core18
-version: 1.3.1
+version: 1.3.2
 summary: Your little expandable text snippet helper
 description: |
   Save your often used text snippets and then expand them whenever you type their abbreviation.

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -21,7 +21,7 @@
 namespace SnippetPixie {
     public class Application : Gtk.Application {
         public const string ID = "com.github.bytepixie.snippetpixie";
-        public const string VERSION = "1.3.1";
+        public const string VERSION = "1.3.2";
 
         private const ulong SLEEP_INTERVAL = (ulong) TimeSpan.MILLISECOND * 10;
         private const ulong SLEEP_INTERVAL_RETRY = SLEEP_INTERVAL * 2;


### PR DESCRIPTION
  * Improved speed of abbreviation expansion.
  * Fixed abbreviations randomly stopping to expand.
  * Fixed reliability of abbreviations being recognised.
  * Fixed abbreviations sometimes expanding with clipboard's contents.