### PR TITLE
Release 1.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Your little expandable text snippet helper.
 
 Save your often used text snippets and then expand them whenever you type their abbreviation.
 
-For example:- "spr`" expands to "Snippet Pixie rules!"
+For example:- "spr\`" expands to "Snippet Pixie rules!"
 
-For non-accessible applications such as browsers and Electron apps, there's a shortcut (default is Ctrl+`) for opening a search window that pastes the selected snippet.
+For non-accessible applications such as browsers and Electron apps, there's a shortcut (default is Ctrl+\`) for opening a search window that pastes the selected snippet.
 
-The Search and Paste window opened with Ctrl+` (can be changed) is very convenient for quickly finding and pasting snippets, and shows the most recently used snippets first for quick access.
+The Search and Paste window opened with Ctrl+\` (can be changed) is very convenient for quickly finding and pasting snippets, and shows the most recently used snippets first for quick access. Using `Shift`+`Return` or `Shift`+`Click` on an entry in the Search and Paste window will `Shift`+`Ctrl`+`V` paste, great for terminal emulators, vim etc.
 
 Snippets can be imported and exported in a simple JSON format.
 

--- a/data/com.github.bytepixie.snippetpixie.appdata.xml.in
+++ b/data/com.github.bytepixie.snippetpixie.appdata.xml.in
@@ -24,6 +24,13 @@
     <binary>com.github.bytepixie.snippetpixie</binary>
   </provides>
   <releases>
+    <release version="1.5.2" date="2021-05-26">
+      <description>
+        <ul>
+          <li>Enable Shift-Return to Shift-Ctrl-V into terminal emulators from the Search and Paste window.</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.5.1" date="2021-03-02">
       <description>
         <ul>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+com.github.bytepixie.snippetpixie (1.5.2) xenial; urgency=medium
+
+  * Enable Shift-Return to Shift-Ctrl-V into terminal emulators from the Search and Paste window.
+
+ -- Byte Pixie <hello@bytepixie.com>  Thu, 26 May 2021 19:30:00 +0000
+
 com.github.bytepixie.snippetpixie (1.5.1) xenial; urgency=medium
 
   * Fixed search box showing when there are no Snippets to search.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: snippetpixie
 base: core20
-version: 1.5.1
+version: 1.5.2
 summary: Your little expandable text snippet helper
 description: |
   Save your often used text snippets and then expand them whenever you type their abbreviation.

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -21,7 +21,7 @@
 namespace SnippetPixie {
     public class Application : Gtk.Application {
         public const string ID = "com.github.bytepixie.snippetpixie";
-        public const string VERSION = "1.5.1";
+        public const string VERSION = "1.5.2";
 
         public signal void search_changed (string search_term);
         public signal void search_escaped ();

--- a/src/Windows/SearchAndPasteWindow.vala
+++ b/src/Windows/SearchAndPasteWindow.vala
@@ -152,12 +152,17 @@ public class SnippetPixie.SearchAndPasteWindow : Gtk.Dialog {
                     }
                     return true;
                 case Gdk.Key.Return:
+                    bool has_selection = list_box.get_selected_rows ().length () > 0;
+                    if (has_selection && Gdk.ModifierType.SHIFT_MASK in event.state) {
+                        list_box.activate_cursor_row ();
+                        return true;
+                    }
                     return false;
                 default:
                     break;
             }
 
-            if (event.keyval != Gdk.Key.Escape && !search_headerbar.is_focus) {
+            if (event.keyval != Gdk.Key.Escape && event.keyval != Gdk.Key.Shift_L && event.keyval != Gdk.Key.Shift_R && !search_headerbar.is_focus) {
                 search_headerbar.grab_focus ();
                 search_headerbar.key_press_event (event);
                 return true;


### PR DESCRIPTION
* Enable `Shift`-`Return` to `Shift`-`Ctrl`-`V` into terminal emulators from the Search and Paste window.