### PR TITLE
Add an auto start on login menu setting.

### DIFF
--- a/data/com.github.bytepixie.snippetpixie.gschema.xml
+++ b/data/com.github.bytepixie.snippetpixie.gschema.xml
@@ -23,6 +23,11 @@
       <summary>Most recent height of Snippet Pixie</summary>
       <description>Most recent height of Snippet Pixie</description>
     </key>
+    <key name="autostart" type="b">
+      <default>true</default>
+      <summary>Should Snippet Pixie autostart on log in?</summary>
+      <description>If turned on, then Snippet Pixie will automatically start in the background when you log in to the desktop</description>
+    </key>
     <key name="auto-expand" type="b">
       <default>true</default>
       <summary>Should Snippet Pixie auto-expand typed abbreviations?</summary>

--- a/po/com.github.bytepixie.snippetpixie.pot
+++ b/po/com.github.bytepixie.snippetpixie.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.bytepixie.snippetpixie\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-05 21:56+0000\n"
+"POT-Creation-Date: 2021-08-19 09:43+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,44 +30,48 @@ msgid "Add Snippet"
 msgstr ""
 
 #: src/Widgets/MainWindowHeader.vala:45
-msgid "Search Snippets"
+msgid "Auto start on login"
 msgstr ""
 
 #: src/Widgets/MainWindowHeader.vala:48
-#: src/Windows/SearchAndPasteWindow.vala:56
-msgid "Search Snippets…"
-msgstr ""
-
-#: src/Widgets/MainWindowHeader.vala:66
 msgid "Auto expand Snippets"
 msgstr ""
 
-#: src/Widgets/MainWindowHeader.vala:69 src/Widgets/MainWindowHeader.vala:103
+#: src/Widgets/MainWindowHeader.vala:51 src/Widgets/MainWindowHeader.vala:86
 msgid "Shortcut"
 msgstr ""
 
-#: src/Widgets/MainWindowHeader.vala:72 src/Widgets/MainWindowHeader.vala:76
+#: src/Widgets/MainWindowHeader.vala:54 src/Widgets/MainWindowHeader.vala:58
 msgid "Import Snippets…"
 msgstr ""
 
-#: src/Widgets/MainWindowHeader.vala:79 src/Widgets/MainWindowHeader.vala:83
+#: src/Widgets/MainWindowHeader.vala:61 src/Widgets/MainWindowHeader.vala:65
 msgid "Export Snippets…"
 msgstr ""
 
-#: src/Widgets/MainWindowHeader.vala:86
+#: src/Widgets/MainWindowHeader.vala:68
 msgid "About…"
 msgstr ""
 
-#: src/Widgets/MainWindowHeader.vala:108
+#: src/Widgets/MainWindowHeader.vala:91
 msgid "Search selected text"
 msgstr ""
 
-#: src/Widgets/MainWindowHeader.vala:111
+#: src/Widgets/MainWindowHeader.vala:94
 msgid "Focus search box"
 msgstr ""
 
-#: src/Widgets/MainWindowHeader.vala:125
+#: src/Widgets/MainWindowHeader.vala:108
 msgid "Shortcut:"
+msgstr ""
+
+#: src/Widgets/MainWindowHeader.vala:154
+msgid "Search Snippets"
+msgstr ""
+
+#: src/Widgets/MainWindowHeader.vala:157
+#: src/Windows/SearchAndPasteWindow.vala:56
+msgid "Search Snippets…"
 msgstr ""
 
 #: src/Widgets/ViewStack.vala:54
@@ -99,7 +103,7 @@ msgstr ""
 msgid "Create your first snippet."
 msgstr ""
 
-#: src/Widgets/WelcomeView.vala:24 src/Windows/MainWindow.vala:154
+#: src/Widgets/WelcomeView.vala:24 src/Windows/MainWindow.vala:155
 msgid "Import Snippets"
 msgstr ""
 
@@ -115,77 +119,77 @@ msgstr ""
 msgid "Learn the basics of how to use Snippet Pixie."
 msgstr ""
 
-#: src/Windows/MainWindow.vala:154
+#: src/Windows/MainWindow.vala:155
 msgid "Import"
 msgstr ""
 
-#: src/Windows/MainWindow.vala:161
+#: src/Windows/MainWindow.vala:162
 msgid "Overwrite Duplicate Snippets?"
 msgstr ""
 
-#: src/Windows/MainWindow.vala:161
+#: src/Windows/MainWindow.vala:162
 msgid ""
 "If any of the snippet abbreviations about to be imported already exist, do "
 "you want to skip importing them or update the existing snippet?"
 msgstr ""
 
-#: src/Windows/MainWindow.vala:162
+#: src/Windows/MainWindow.vala:163
 msgid "Update Existing"
 msgstr ""
 
-#: src/Windows/MainWindow.vala:163
+#: src/Windows/MainWindow.vala:164
 msgid "Cancel"
 msgstr ""
 
-#: src/Windows/MainWindow.vala:164
+#: src/Windows/MainWindow.vala:165
 msgid "Skip Duplicates"
 msgstr ""
 
-#: src/Windows/MainWindow.vala:191
+#: src/Windows/MainWindow.vala:192
 msgid "Imported Snippets"
 msgstr ""
 
-#: src/Windows/MainWindow.vala:191
+#: src/Windows/MainWindow.vala:192
 msgid "Your snippets were successfully imported."
 msgstr ""
 
-#: src/Windows/MainWindow.vala:195
+#: src/Windows/MainWindow.vala:196
 msgid "Failed to import selected file"
 msgstr ""
 
-#: src/Windows/MainWindow.vala:195
+#: src/Windows/MainWindow.vala:196
 msgid ""
 "Snippet Pixie can currently only import the JSON format files that it also "
 "exports."
 msgstr ""
 
-#: src/Windows/MainWindow.vala:203
+#: src/Windows/MainWindow.vala:204
 msgid "Export Snippets"
 msgstr ""
 
-#: src/Windows/MainWindow.vala:211
+#: src/Windows/MainWindow.vala:212
 msgid "Exported Snippets"
 msgstr ""
 
-#: src/Windows/MainWindow.vala:211
+#: src/Windows/MainWindow.vala:212
 msgid "Your snippets were successfully exported."
 msgstr ""
 
-#: src/Windows/MainWindow.vala:215
+#: src/Windows/MainWindow.vala:216
 msgid "Failed to export to file"
 msgstr ""
 
-#: src/Windows/MainWindow.vala:215
+#: src/Windows/MainWindow.vala:216
 msgid "Something went wrong, sorry."
 msgstr ""
 
-#: src/Windows/MainWindow.vala:233
+#: src/Windows/MainWindow.vala:236
 msgid ""
 "@NathanBnm https://github.com/NathanBnm/\n"
 "            @Vistaus https://github.com/Vistaus/"
 msgstr ""
 
-#: src/Windows/MainWindow.vala:237
+#: src/Windows/MainWindow.vala:240
 msgid "Copyright © Byte Pixie Limited"
 msgstr ""
 
@@ -193,133 +197,133 @@ msgstr ""
 msgid "Please add some snippets!"
 msgstr ""
 
-#: src/Application.vala:640
+#: src/Application.vala:652
 msgid "snippet"
 msgstr ""
 
-#: src/Application.vala:682 src/Application.vala:800
+#: src/Application.vala:694 src/Application.vala:812
 msgid "date"
 msgstr ""
 
-#: src/Application.vala:682 src/Application.vala:804
+#: src/Application.vala:694 src/Application.vala:816
 msgid "time"
 msgstr ""
 
-#: src/Application.vala:716
+#: src/Application.vala:728
 #, c-format
 msgid ""
 "Date adjustment does not seem to have a positive or negative integer in "
 "placeholder '%1$s'."
 msgstr ""
 
-#: src/Application.vala:731
+#: src/Application.vala:743
 #, c-format
 msgid ""
 "Date adjustment number %1$d does not seem to start with a positive or "
 "negative integer in placeholder '%2$s'."
 msgstr ""
 
-#: src/Application.vala:762
+#: src/Application.vala:774
 #, c-format
 msgid ""
 "Date adjustment number %1$d does not seem to end with either 'Y', 'M', 'W', "
 "'D', 'h', 'm' or 's' in placeholder '%2$s'."
 msgstr ""
 
-#: src/Application.vala:770 src/Application.vala:783
+#: src/Application.vala:782 src/Application.vala:795
 #, c-format
 msgid "Oops, date format '%1$s' could not be parsed."
 msgstr ""
 
-#: src/Application.vala:812
+#: src/Application.vala:824
 msgid "clipboard"
 msgstr ""
 
-#: src/Application.vala:848
+#: src/Application.vala:860
 msgid "cursor"
 msgstr ""
 
-#: src/Application.vala:1170
+#: src/Application.vala:1203
 msgid "Show Snippet Pixie's window (default action)"
 msgstr ""
 
-#: src/Application.vala:1171
+#: src/Application.vala:1204
 msgid "Show Snippet Pixie's quick search and paste window"
 msgstr ""
 
-#: src/Application.vala:1172
+#: src/Application.vala:1205
 msgid "Start with no window"
 msgstr ""
 
-#: src/Application.vala:1173
+#: src/Application.vala:1206
 msgid "Fully quit the application, including the background process"
 msgstr ""
 
-#: src/Application.vala:1174
+#: src/Application.vala:1207
 msgid ""
 "Turn auto start of Snippet Pixie on login, on, off, or show status of setting"
 msgstr ""
 
-#: src/Application.vala:1175
+#: src/Application.vala:1208
 msgid ""
 "Shows status of the application, exits with status 0 if running, 1 if not"
 msgstr ""
 
-#: src/Application.vala:1176
+#: src/Application.vala:1209
 msgid "Export snippets to file"
 msgstr ""
 
-#: src/Application.vala:1177
+#: src/Application.vala:1210
 msgid ""
 "Import snippets from file, skips snippets where abbreviation already exists"
 msgstr ""
 
-#: src/Application.vala:1177
+#: src/Application.vala:1210
 msgid "filename"
 msgstr ""
 
-#: src/Application.vala:1178
+#: src/Application.vala:1211
 msgid ""
 "If used in conjunction with import, existing snippets with same abbreviation "
 "are updated"
 msgstr ""
 
-#: src/Application.vala:1179
+#: src/Application.vala:1212
 msgid "Display version number"
 msgstr ""
 
-#: src/Application.vala:1180
+#: src/Application.vala:1213
 msgid "Display this help"
 msgstr ""
 
-#: src/Application.vala:1199
+#: src/Application.vala:1232
 #, c-format
 msgid "error: %s\n"
 msgstr ""
 
-#: src/Application.vala:1200
+#: src/Application.vala:1233
 #, c-format
 msgid "Run '%s --help' to see a full list of available command line options.\n"
 msgstr ""
 
-#: src/Application.vala:1216
+#: src/Application.vala:1249
 msgid "Quitting…\n"
 msgstr ""
 
-#: src/Application.vala:1224
+#: src/Application.vala:1257
 msgid "Running.\n"
 msgstr ""
 
-#: src/Application.vala:1227
+#: src/Application.vala:1260
 msgid "Not Running.\n"
 msgstr ""
 
-#: src/Application.vala:1249
+#: src/Application.vala:1285
 #, c-format
 msgid "Invalid autostart value \"%s\".\n"
 msgstr ""
 
-#: src/Application.vala:1295
+#: src/Application.vala:1330
 msgid "Cannot run without threads.\n"
 msgstr ""
 

--- a/po/extra/extra.pot
+++ b/po/extra/extra.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-05 21:56+0000\n"
+"POT-Creation-Date: 2021-08-19 09:43+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,24 +49,24 @@ msgid "Supports placeholders:-"
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:15
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:117
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:132
 msgid ""
 "Date/Time: Insert the current or calculated date/time with configurable "
 "format."
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:16
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:118
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:133
 msgid "Clipboard: Insert the text contents of the clipboard."
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:17
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:119
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:134
 msgid "Snippets: Insert snippets in your snippets!"
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:18
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:120
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:135
 msgid ""
 "Cursor: Set where the cursor should end up after the snippet has expanded."
 msgstr ""
@@ -82,228 +82,242 @@ msgid "For example, today's date can be inserted with \"$$@date$$\"."
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:30
+msgid ""
+"Enable Shift-Return to Shift-Ctrl-V into terminal emulators from the Search "
+"and Paste window."
+msgstr ""
+
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:37
+msgid "Fixed search box showing when there are no Snippets to search."
+msgstr ""
+
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:38
+msgid "Updated Dutch translations. Thanks @Vistaus on GitHub! 🇳🇱"
+msgstr ""
+
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:45
 msgid "Added search of Snippets in main window."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:31
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:46
 msgid "Added last used Snippets shown first in Search and Paste window."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:32
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:47
 msgid "Added shortcuts for main window actions such as Add Snippet (Ctrl+n)."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:33
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:48
 msgid "Added support for system Light and Dark appearance preference."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:34
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:49
 msgid "Improved theming of window controls to be more consistent with system."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:41
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:56
 msgid "Added Dutch translations. Huge thanks to @Vistaus on GitHub! 🇳🇱"
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:42
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:57
 msgid "Fixed occasional performance issues when auto-expand turned on."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:43
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:58
 msgid "Fixed incorrect shortcut command being saved when binary file renamed."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:44
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:59
 msgid "Fixed visibility of Search and Paste entry text in some circumstances."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:51
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:66
 msgid "Added Search and Paste window, opened with shortcut Ctrl+` by default."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:52
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:67
 msgid ""
 "Added \"Auto expand snippets\" checkbox to preferences menu for enabling/"
 "disabling snippet expansion while typing in accessible apps."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:53
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:68
 msgid "Added ability to change Search and Paste shortcut in preferences menu."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:54
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:69
 msgid ""
 "Added preference for whether text selected before using shortcut is used for "
 "initial search."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:55
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:70
 msgid ""
 "Added option to focus search box when using the search and paste shortcut."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:56
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:71
 msgid "Fixed support for Wayland."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:57
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:72
 msgid ""
 "Removed auto expanding of snippets in non-accessible applications such as "
 "browsers and electron apps (use shortcut for search and paste window "
 "instead)."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:64
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:79
 msgid "Fixed Snippet Pixie stopping Super+[other-key] from working."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:71
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:86
 msgid "Improved speed of abbreviation expansion."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:72
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:87
 msgid "Fixed abbreviations randomly stopping to expand."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:73
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:88
 msgid "Fixed reliability of abbreviations being recognised."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:74
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:89
 msgid "Fixed abbreviations sometimes expanding with clipboard's contents."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:81
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:96
 msgid "Fixed abbreviations sometimes not expanding."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:88
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:103
 msgid "Vastly improved compatibility with a wide variety of applications."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:89
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:104
 msgid "Now works with Chrome, Chromium and Electron apps."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:90
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:105
 msgid "Much faster abbreviation detection."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:91
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:106
 msgid "Much nicer to the system in general."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:92
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:107
 msgid ""
 "Alas, recent Firefox versions no longer compatible, hope to support in the "
 "future."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:93
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:108
 msgid ""
 "A few terminal emulators blacklisted to avoid problems, hope to support in "
 "the future."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:100
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:115
 msgid "Added man pages for snippetpixie and snippetpixie-placeholders."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:101
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:116
 msgid "Minor fixes for compile time warnings."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:108
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:123
 msgid "Various fixes for snap."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:109
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:124
 msgid ""
 "Updated credits to use GitHub handles and add Nathan as a translator (long "
 "overdue)!"
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:115
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:130
 msgid "Added support for placeholders."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:127
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:142
 msgid "Improved active window/control detection when switching via Alt-Tab."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:134
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:149
 msgid "Improved performance, compatibility, and stability."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:135
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:150
 msgid "Added French translations. Huge thanks to @NathanBnm on GitHub! 🇨🇵️"
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:142
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:157
 msgid "Added ability to export snippets to a JSON file via menu button."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:143
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:158
 msgid ""
 "Added ability to export snippets to a JSON file via `--export` or `-e` CLI "
 "options."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:144
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:159
 msgid ""
 "Added ability to import snippets from an exported JSON file via menu button "
 "or welcome screen. Shocking! 😱"
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:145
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:160
 msgid ""
 "Added ability to import snippets from an exported JSON file via `--import` "
 "or `-i` CLI options. Bet you didn't see that coming! 😉"
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:152
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:167
 msgid "1.0 Release!"
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:153
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:168
 msgid "Added Snippet Pixie to login startup items by default."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:154
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:169
 msgid ""
 "Added --autostart={on|off|status} option to CLI for turning autostart on, "
 "off, or getting settings status."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:155
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:170
 msgid "Changed body field to select all text when tabbed into."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:162
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:177
 msgid ""
 "Fixed crash when an application with a large number of controls was "
 "activated."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:163
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:178
 msgid ""
 "Fixed problem with snippets sometimes not expanding when returning to an "
 "application."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:164
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:179
 msgid "Added a splash of colour to the window header."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:165
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:180
 msgid "Added a new application icon."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:171
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:186
 msgid "Initial pre-release."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:221
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:236
 msgid "Byte Pixie"
 msgstr ""
 

--- a/po/extra/fr.po
+++ b/po/extra/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.bytepixie.snippetpixie\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-05 21:56+0000\n"
+"POT-Creation-Date: 2021-08-19 09:43+0100\n"
 "PO-Revision-Date: 2019-02-06 22:35+0100\n"
 "Last-Translator: NathanBnm\n"
 "Language-Team: Français\n"
@@ -51,24 +51,24 @@ msgid "Supports placeholders:-"
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:15
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:117
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:132
 msgid ""
 "Date/Time: Insert the current or calculated date/time with configurable "
 "format."
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:16
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:118
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:133
 msgid "Clipboard: Insert the text contents of the clipboard."
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:17
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:119
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:134
 msgid "Snippets: Insert snippets in your snippets!"
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:18
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:120
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:135
 msgid ""
 "Cursor: Set where the cursor should end up after the snippet has expanded."
 msgstr ""
@@ -84,173 +84,187 @@ msgid "For example, today's date can be inserted with \"$$@date$$\"."
 msgstr ""
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:30
+msgid ""
+"Enable Shift-Return to Shift-Ctrl-V into terminal emulators from the Search "
+"and Paste window."
+msgstr ""
+
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:37
+msgid "Fixed search box showing when there are no Snippets to search."
+msgstr ""
+
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:38
+msgid "Updated Dutch translations. Thanks @Vistaus on GitHub! 🇳🇱"
+msgstr ""
+
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:45
 msgid "Added search of Snippets in main window."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:31
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:46
 msgid "Added last used Snippets shown first in Search and Paste window."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:32
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:47
 msgid "Added shortcuts for main window actions such as Add Snippet (Ctrl+n)."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:33
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:48
 msgid "Added support for system Light and Dark appearance preference."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:34
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:49
 msgid "Improved theming of window controls to be more consistent with system."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:41
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:56
 msgid "Added Dutch translations. Huge thanks to @Vistaus on GitHub! 🇳🇱"
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:42
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:57
 msgid "Fixed occasional performance issues when auto-expand turned on."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:43
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:58
 msgid "Fixed incorrect shortcut command being saved when binary file renamed."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:44
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:59
 msgid "Fixed visibility of Search and Paste entry text in some circumstances."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:51
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:66
 msgid "Added Search and Paste window, opened with shortcut Ctrl+` by default."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:52
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:67
 msgid ""
 "Added \"Auto expand snippets\" checkbox to preferences menu for enabling/"
 "disabling snippet expansion while typing in accessible apps."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:53
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:68
 msgid "Added ability to change Search and Paste shortcut in preferences menu."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:54
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:69
 msgid ""
 "Added preference for whether text selected before using shortcut is used for "
 "initial search."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:55
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:70
 msgid ""
 "Added option to focus search box when using the search and paste shortcut."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:56
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:71
 msgid "Fixed support for Wayland."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:57
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:72
 msgid ""
 "Removed auto expanding of snippets in non-accessible applications such as "
 "browsers and electron apps (use shortcut for search and paste window "
 "instead)."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:64
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:79
 msgid "Fixed Snippet Pixie stopping Super+[other-key] from working."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:71
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:86
 msgid "Improved speed of abbreviation expansion."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:72
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:87
 msgid "Fixed abbreviations randomly stopping to expand."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:73
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:88
 msgid "Fixed reliability of abbreviations being recognised."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:74
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:89
 msgid "Fixed abbreviations sometimes expanding with clipboard's contents."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:81
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:96
 msgid "Fixed abbreviations sometimes not expanding."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:88
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:103
 msgid "Vastly improved compatibility with a wide variety of applications."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:89
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:104
 msgid "Now works with Chrome, Chromium and Electron apps."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:90
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:105
 msgid "Much faster abbreviation detection."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:91
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:106
 msgid "Much nicer to the system in general."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:92
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:107
 msgid ""
 "Alas, recent Firefox versions no longer compatible, hope to support in the "
 "future."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:93
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:108
 msgid ""
 "A few terminal emulators blacklisted to avoid problems, hope to support in "
 "the future."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:100
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:115
 msgid "Added man pages for snippetpixie and snippetpixie-placeholders."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:101
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:116
 msgid "Minor fixes for compile time warnings."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:108
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:123
 msgid "Various fixes for snap."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:109
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:124
 msgid ""
 "Updated credits to use GitHub handles and add Nathan as a translator (long "
 "overdue)!"
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:115
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:130
 msgid "Added support for placeholders."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:127
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:142
 msgid "Improved active window/control detection when switching via Alt-Tab."
 msgstr ""
 "Amélioration de la détection de la mise au premier plan de la fenêtre lors "
 "du défilement avec Alt+Tab."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:134
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:149
 msgid "Improved performance, compatibility, and stability."
 msgstr ""
 "Amélioration de la performance, de la compatibilité et de la stabilité."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:135
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:150
 msgid "Added French translations. Huge thanks to @NathanBnm on GitHub! 🇨🇵️"
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:142
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:157
 msgid "Added ability to export snippets to a JSON file via menu button."
 msgstr ""
 "Ajout de la possibilité d'exporter des raccourcis vers un fichier JSON via "
 "un bouton de menu."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:143
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:158
 msgid ""
 "Added ability to export snippets to a JSON file via `--export` or `-e` CLI "
 "options."
@@ -258,7 +272,7 @@ msgstr ""
 "Ajout de la possibilité d'exporter des extraits vers un fichier JSON via les "
 "options en ligne de commande `--export` ou `-e`."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:144
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:159
 msgid ""
 "Added ability to import snippets from an exported JSON file via menu button "
 "or welcome screen. Shocking! 😱"
@@ -266,7 +280,7 @@ msgstr ""
 "Ajout de la possibilité d'importer des extraits d'un fichier JSON exporté "
 "via un bouton de menu ou depuis l'écran de bienvenue. Choquant ! 😱"
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:145
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:160
 msgid ""
 "Added ability to import snippets from an exported JSON file via `--import` "
 "or `-i` CLI options. Bet you didn't see that coming! 😉"
@@ -275,16 +289,16 @@ msgstr ""
 "options en ligne de commande `--import` ou `-i`. Je parie que vous ne "
 "l'aviez pas vu venir ! 😉"
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:152
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:167
 msgid "1.0 Release!"
 msgstr "Version 1.0 !"
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:153
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:168
 msgid "Added Snippet Pixie to login startup items by default."
 msgstr ""
 "Ajout de Snippet Pixie aux éléments de démarrage par défaut à la connexion."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:154
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:169
 msgid ""
 "Added --autostart={on|off|status} option to CLI for turning autostart on, "
 "off, or getting settings status."
@@ -292,13 +306,13 @@ msgstr ""
 "Ajout de l'option --autostart={on|off|status} aux lignes de commande pour "
 "activer, désactiver ou obtenir le statut des paramètres."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:155
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:170
 msgid "Changed body field to select all text when tabbed into."
 msgstr ""
 "Changement du champ de texte pour sélectionner tout le texte lorsqu'il est "
 "affiché sous forme d'onglets."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:162
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:177
 msgid ""
 "Fixed crash when an application with a large number of controls was "
 "activated."
@@ -306,7 +320,7 @@ msgstr ""
 "Correction d'un plantage lorsqu'une application avec un grand nombre de "
 "contrôles était activée."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:163
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:178
 msgid ""
 "Fixed problem with snippets sometimes not expanding when returning to an "
 "application."
@@ -314,19 +328,19 @@ msgstr ""
 "Correction d'un problème avec les raccourcis qui ne se développaient pas "
 "toujours lors du retour à une application."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:164
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:179
 msgid "Added a splash of colour to the window header."
 msgstr "Ajout d'une touche de couleur à l'en-tête de la fenêtre."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:165
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:180
 msgid "Added a new application icon."
 msgstr "Ajout d'une nouvelle icône d'application."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:171
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:186
 msgid "Initial pre-release."
 msgstr "Pré-version initiale."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:221
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:236
 msgid "Byte Pixie"
 msgstr "Byte Pixie"
 

--- a/po/extra/nl.po
+++ b/po/extra/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-05 21:56+0000\n"
+"POT-Creation-Date: 2021-08-19 09:43+0100\n"
 "PO-Revision-Date: 2020-11-06 17:30+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language-Team: \n"
@@ -55,7 +55,7 @@ msgid "Supports placeholders:-"
 msgstr "Ondersteunt plaatshouders:-"
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:15
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:117
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:132
 msgid ""
 "Date/Time: Insert the current or calculated date/time with configurable "
 "format."
@@ -63,17 +63,17 @@ msgstr ""
 "Datum/Tijd: voeg de huidige of berekende datum en tijd in (instelbaar)."
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:16
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:118
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:133
 msgid "Clipboard: Insert the text contents of the clipboard."
 msgstr "Klembord: plak de klembordinhoud."
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:17
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:119
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:134
 msgid "Snippets: Insert snippets in your snippets!"
 msgstr "Knipsels: voeg knipsels in in je knipsels!"
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:18
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:120
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:135
 msgid ""
 "Cursor: Set where the cursor should end up after the snippet has expanded."
 msgstr ""
@@ -93,52 +93,68 @@ msgid "For example, today's date can be inserted with \"$$@date$$\"."
 msgstr "Voorbeeld: de huidige datum kan worden ingevoegd met '$$@date$$'."
 
 #: data/com.github.bytepixie.snippetpixie.appdata.xml.in:30
+msgid ""
+"Enable Shift-Return to Shift-Ctrl-V into terminal emulators from the Search "
+"and Paste window."
+msgstr ""
+
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:37
+msgid "Fixed search box showing when there are no Snippets to search."
+msgstr ""
+
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:38
+#, fuzzy
+msgid "Updated Dutch translations. Thanks @Vistaus on GitHub! 🇳🇱"
+msgstr ""
+"Nederlandse vertaling toegevoegd, met veel dank aan @Vistaus op GitHub! 🇳🇱"
+
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:45
 msgid "Added search of Snippets in main window."
 msgstr "Zoekvak toegevoegd aan hoofdvenster."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:31
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:46
 msgid "Added last used Snippets shown first in Search and Paste window."
 msgstr "Recentste knipsels toegevoegd aan het zoeken-en-plakkenvenster."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:32
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:47
 msgid "Added shortcuts for main window actions such as Add Snippet (Ctrl+n)."
 msgstr ""
 "Sneltoetsen toegevoegd voor hoofdvensteracties, zoals 'Knipsel "
 "toevoegen' (Ctrl+n)."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:33
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:48
 msgid "Added support for system Light and Dark appearance preference."
 msgstr "Ondersteuning voor lichte en donkere systeemthema's."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:34
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:49
 msgid "Improved theming of window controls to be more consistent with system."
 msgstr ""
 "Vormgeving van vensterknoppen verbeterd zodat ze beter integreren met het "
 "systeem."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:41
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:56
 msgid "Added Dutch translations. Huge thanks to @Vistaus on GitHub! 🇳🇱"
 msgstr ""
 "Nederlandse vertaling toegevoegd, met veel dank aan @Vistaus op GitHub! 🇳🇱"
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:42
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:57
 msgid "Fixed occasional performance issues when auto-expand turned on."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:43
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:58
 msgid "Fixed incorrect shortcut command being saved when binary file renamed."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:44
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:59
 msgid "Fixed visibility of Search and Paste entry text in some circumstances."
 msgstr "Zichtbaarheid van de zoeken-en-plakkentekst verbeterd."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:51
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:66
 msgid "Added Search and Paste window, opened with shortcut Ctrl+` by default."
 msgstr ""
 "Zoeken-en-plakkenvenster toegevoegd, wat kan worden geopend met Ctrl+`."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:52
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:67
 msgid ""
 "Added \"Auto expand snippets\" checkbox to preferences menu for enabling/"
 "disabling snippet expansion while typing in accessible apps."
@@ -146,12 +162,12 @@ msgstr ""
 "Optie 'Knipsels automatisch invoegen' toegevoegd aan de voorkeuren voor het "
 "invoegen van knipsels in toegankelijke toepassingen."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:53
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:68
 msgid "Added ability to change Search and Paste shortcut in preferences menu."
 msgstr ""
 "Mogelijkheid toegevoegd om de sneltoets zoeken-en-plakken aan te passen."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:54
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:69
 msgid ""
 "Added preference for whether text selected before using shortcut is used for "
 "initial search."
@@ -159,18 +175,18 @@ msgstr ""
 "Instelling toegevoegd om al dan niet te zoeken naar geselecteerde tekst bij "
 "gebruik van de sneltoets."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:55
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:70
 msgid ""
 "Added option to focus search box when using the search and paste shortcut."
 msgstr ""
 "Instelling toegevoegd om het zoekvak te focussen bij gebruik van de zoeken-"
 "en-plakkensneltoets."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:56
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:71
 msgid "Fixed support for Wayland."
 msgstr "Wayland-ondersteuning gerepareerd."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:57
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:72
 msgid ""
 "Removed auto expanding of snippets in non-accessible applications such as "
 "browsers and electron apps (use shortcut for search and paste window "
@@ -180,157 +196,157 @@ msgstr ""
 "webbrowsers en Electron-toepassingen (gebruik in plaats daarvan de sneltoets "
 "voor zoeken-en-plakken)."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:64
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:79
 msgid "Fixed Snippet Pixie stopping Super+[other-key] from working."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:71
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:86
 msgid "Improved speed of abbreviation expansion."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:72
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:87
 msgid "Fixed abbreviations randomly stopping to expand."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:73
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:88
 msgid "Fixed reliability of abbreviations being recognised."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:74
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:89
 msgid "Fixed abbreviations sometimes expanding with clipboard's contents."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:81
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:96
 msgid "Fixed abbreviations sometimes not expanding."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:88
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:103
 msgid "Vastly improved compatibility with a wide variety of applications."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:89
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:104
 msgid "Now works with Chrome, Chromium and Electron apps."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:90
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:105
 msgid "Much faster abbreviation detection."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:91
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:106
 msgid "Much nicer to the system in general."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:92
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:107
 msgid ""
 "Alas, recent Firefox versions no longer compatible, hope to support in the "
 "future."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:93
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:108
 msgid ""
 "A few terminal emulators blacklisted to avoid problems, hope to support in "
 "the future."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:100
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:115
 msgid "Added man pages for snippetpixie and snippetpixie-placeholders."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:101
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:116
 msgid "Minor fixes for compile time warnings."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:108
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:123
 msgid "Various fixes for snap."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:109
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:124
 msgid ""
 "Updated credits to use GitHub handles and add Nathan as a translator (long "
 "overdue)!"
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:115
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:130
 msgid "Added support for placeholders."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:127
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:142
 msgid "Improved active window/control detection when switching via Alt-Tab."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:134
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:149
 msgid "Improved performance, compatibility, and stability."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:135
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:150
 msgid "Added French translations. Huge thanks to @NathanBnm on GitHub! 🇨🇵️"
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:142
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:157
 msgid "Added ability to export snippets to a JSON file via menu button."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:143
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:158
 msgid ""
 "Added ability to export snippets to a JSON file via `--export` or `-e` CLI "
 "options."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:144
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:159
 msgid ""
 "Added ability to import snippets from an exported JSON file via menu button "
 "or welcome screen. Shocking! 😱"
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:145
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:160
 msgid ""
 "Added ability to import snippets from an exported JSON file via `--import` "
 "or `-i` CLI options. Bet you didn't see that coming! 😉"
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:152
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:167
 msgid "1.0 Release!"
 msgstr "1.0-uitgave!"
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:153
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:168
 msgid "Added Snippet Pixie to login startup items by default."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:154
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:169
 msgid ""
 "Added --autostart={on|off|status} option to CLI for turning autostart on, "
 "off, or getting settings status."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:155
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:170
 msgid "Changed body field to select all text when tabbed into."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:162
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:177
 msgid ""
 "Fixed crash when an application with a large number of controls was "
 "activated."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:163
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:178
 msgid ""
 "Fixed problem with snippets sometimes not expanding when returning to an "
 "application."
 msgstr ""
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:164
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:179
 msgid "Added a splash of colour to the window header."
 msgstr "Vensterkop voorzien van kleur."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:165
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:180
 msgid "Added a new application icon."
 msgstr "Nieuw toepassingspictogram."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:171
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:186
 msgid "Initial pre-release."
 msgstr "Initiële uitgave."
 
-#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:221
+#: data/com.github.bytepixie.snippetpixie.appdata.xml.in:236
 msgid "Byte Pixie"
 msgstr "Byte Pixie"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.bytepixie.snippetpixie\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-05 21:56+0000\n"
+"POT-Creation-Date: 2021-08-19 09:43+0100\n"
 "PO-Revision-Date: 2019-02-06 22:35+0100\n"
 "Last-Translator: NathanBnm\n"
 "Language-Team: Français\n"
@@ -30,50 +30,54 @@ msgid "Add Snippet"
 msgstr "Ajouter un raccourci"
 
 #: src/Widgets/MainWindowHeader.vala:45
-#, fuzzy
-msgid "Search Snippets"
-msgstr "Importer des raccourcis…"
+msgid "Auto start on login"
+msgstr ""
 
 #: src/Widgets/MainWindowHeader.vala:48
-#: src/Windows/SearchAndPasteWindow.vala:56
-#, fuzzy
-msgid "Search Snippets…"
-msgstr "Importer des raccourcis…"
-
-#: src/Widgets/MainWindowHeader.vala:66
 #, fuzzy
 msgid "Auto expand Snippets"
 msgstr "Ajouter un raccourci"
 
-#: src/Widgets/MainWindowHeader.vala:69 src/Widgets/MainWindowHeader.vala:103
+#: src/Widgets/MainWindowHeader.vala:51 src/Widgets/MainWindowHeader.vala:86
 msgid "Shortcut"
 msgstr ""
 
-#: src/Widgets/MainWindowHeader.vala:72 src/Widgets/MainWindowHeader.vala:76
+#: src/Widgets/MainWindowHeader.vala:54 src/Widgets/MainWindowHeader.vala:58
 #, fuzzy
 msgid "Import Snippets…"
 msgstr "Importer des raccourcis…"
 
-#: src/Widgets/MainWindowHeader.vala:79 src/Widgets/MainWindowHeader.vala:83
+#: src/Widgets/MainWindowHeader.vala:61 src/Widgets/MainWindowHeader.vala:65
 #, fuzzy
 msgid "Export Snippets…"
 msgstr "Exporter des raccourcis…"
 
-#: src/Widgets/MainWindowHeader.vala:86
+#: src/Widgets/MainWindowHeader.vala:68
 msgid "About…"
 msgstr "À propos…"
 
-#: src/Widgets/MainWindowHeader.vala:108
+#: src/Widgets/MainWindowHeader.vala:91
 msgid "Search selected text"
 msgstr ""
 
-#: src/Widgets/MainWindowHeader.vala:111
+#: src/Widgets/MainWindowHeader.vala:94
 msgid "Focus search box"
 msgstr ""
 
-#: src/Widgets/MainWindowHeader.vala:125
+#: src/Widgets/MainWindowHeader.vala:108
 msgid "Shortcut:"
 msgstr ""
+
+#: src/Widgets/MainWindowHeader.vala:154
+#, fuzzy
+msgid "Search Snippets"
+msgstr "Importer des raccourcis…"
+
+#: src/Widgets/MainWindowHeader.vala:157
+#: src/Windows/SearchAndPasteWindow.vala:56
+#, fuzzy
+msgid "Search Snippets…"
+msgstr "Importer des raccourcis…"
 
 #: src/Widgets/ViewStack.vala:54
 msgid "Abbreviation"
@@ -105,7 +109,7 @@ msgstr "Aucun raccourci trouvé."
 msgid "Create your first snippet."
 msgstr "Créez votre premier raccourci."
 
-#: src/Widgets/WelcomeView.vala:24 src/Windows/MainWindow.vala:154
+#: src/Widgets/WelcomeView.vala:24 src/Windows/MainWindow.vala:155
 msgid "Import Snippets"
 msgstr "Importer des raccourcis"
 
@@ -121,15 +125,15 @@ msgstr "Guide de démarrage rapide"
 msgid "Learn the basics of how to use Snippet Pixie."
 msgstr "Apprenez les bases de l'utilisation de Snippet Pixie."
 
-#: src/Windows/MainWindow.vala:154
+#: src/Windows/MainWindow.vala:155
 msgid "Import"
 msgstr "Importer"
 
-#: src/Windows/MainWindow.vala:161
+#: src/Windows/MainWindow.vala:162
 msgid "Overwrite Duplicate Snippets?"
 msgstr "Écraser les raccourcis en double ?"
 
-#: src/Windows/MainWindow.vala:161
+#: src/Windows/MainWindow.vala:162
 msgid ""
 "If any of the snippet abbreviations about to be imported already exist, do "
 "you want to skip importing them or update the existing snippet?"
@@ -138,31 +142,31 @@ msgstr ""
 "déjà, voulez-vous sauter l'importation ou mettre à jour le raccourci "
 "existant ?"
 
-#: src/Windows/MainWindow.vala:162
+#: src/Windows/MainWindow.vala:163
 msgid "Update Existing"
 msgstr "Mettre à jour l'existant"
 
-#: src/Windows/MainWindow.vala:163
+#: src/Windows/MainWindow.vala:164
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/Windows/MainWindow.vala:164
+#: src/Windows/MainWindow.vala:165
 msgid "Skip Duplicates"
 msgstr "Ignorer les doublons"
 
-#: src/Windows/MainWindow.vala:191
+#: src/Windows/MainWindow.vala:192
 msgid "Imported Snippets"
 msgstr "Raccourcis importés"
 
-#: src/Windows/MainWindow.vala:191
+#: src/Windows/MainWindow.vala:192
 msgid "Your snippets were successfully imported."
 msgstr "Vos raccourcis ont été importés avec succès."
 
-#: src/Windows/MainWindow.vala:195
+#: src/Windows/MainWindow.vala:196
 msgid "Failed to import selected file"
 msgstr "Échec de l'importation du fichier sélectionné"
 
-#: src/Windows/MainWindow.vala:195
+#: src/Windows/MainWindow.vala:196
 msgid ""
 "Snippet Pixie can currently only import the JSON format files that it also "
 "exports."
@@ -170,33 +174,33 @@ msgstr ""
 "Snippet Pixie ne peut actuellement importer que les fichiers au format JSON "
 "qu'il exporte également."
 
-#: src/Windows/MainWindow.vala:203
+#: src/Windows/MainWindow.vala:204
 msgid "Export Snippets"
 msgstr "Exporter les raccourcis"
 
-#: src/Windows/MainWindow.vala:211
+#: src/Windows/MainWindow.vala:212
 msgid "Exported Snippets"
 msgstr "Raccourcis exportés"
 
-#: src/Windows/MainWindow.vala:211
+#: src/Windows/MainWindow.vala:212
 msgid "Your snippets were successfully exported."
 msgstr "Vos raccourcis ont été exportés avec succès."
 
-#: src/Windows/MainWindow.vala:215
+#: src/Windows/MainWindow.vala:216
 msgid "Failed to export to file"
 msgstr "Échec de l'exportation du fichier"
 
-#: src/Windows/MainWindow.vala:215
+#: src/Windows/MainWindow.vala:216
 msgid "Something went wrong, sorry."
 msgstr "Une erreur s'est produite, désolé."
 
-#: src/Windows/MainWindow.vala:233
+#: src/Windows/MainWindow.vala:236
 msgid ""
 "@NathanBnm https://github.com/NathanBnm/\n"
 "            @Vistaus https://github.com/Vistaus/"
 msgstr ""
 
-#: src/Windows/MainWindow.vala:237
+#: src/Windows/MainWindow.vala:240
 #, fuzzy
 msgid "Copyright © Byte Pixie Limited"
 msgstr "Copyright © Byte Pixie Limited"
@@ -205,101 +209,101 @@ msgstr "Copyright © Byte Pixie Limited"
 msgid "Please add some snippets!"
 msgstr ""
 
-#: src/Application.vala:640
+#: src/Application.vala:652
 #, fuzzy
 msgid "snippet"
 msgstr "Ajouter un raccourci"
 
-#: src/Application.vala:682 src/Application.vala:800
+#: src/Application.vala:694 src/Application.vala:812
 msgid "date"
 msgstr ""
 
-#: src/Application.vala:682 src/Application.vala:804
+#: src/Application.vala:694 src/Application.vala:816
 msgid "time"
 msgstr ""
 
-#: src/Application.vala:716
+#: src/Application.vala:728
 #, c-format
 msgid ""
 "Date adjustment does not seem to have a positive or negative integer in "
 "placeholder '%1$s'."
 msgstr ""
 
-#: src/Application.vala:731
+#: src/Application.vala:743
 #, c-format
 msgid ""
 "Date adjustment number %1$d does not seem to start with a positive or "
 "negative integer in placeholder '%2$s'."
 msgstr ""
 
-#: src/Application.vala:762
+#: src/Application.vala:774
 #, c-format
 msgid ""
 "Date adjustment number %1$d does not seem to end with either 'Y', 'M', 'W', "
 "'D', 'h', 'm' or 's' in placeholder '%2$s'."
 msgstr ""
 
-#: src/Application.vala:770 src/Application.vala:783
+#: src/Application.vala:782 src/Application.vala:795
 #, c-format
 msgid "Oops, date format '%1$s' could not be parsed."
 msgstr ""
 
-#: src/Application.vala:812
+#: src/Application.vala:824
 msgid "clipboard"
 msgstr ""
 
-#: src/Application.vala:848
+#: src/Application.vala:860
 msgid "cursor"
 msgstr ""
 
-#: src/Application.vala:1170
+#: src/Application.vala:1203
 msgid "Show Snippet Pixie's window (default action)"
 msgstr "Afficher la fenêtre de Snippet Pixie (action par défaut)"
 
-#: src/Application.vala:1171
+#: src/Application.vala:1204
 #, fuzzy
 msgid "Show Snippet Pixie's quick search and paste window"
 msgstr "Afficher la fenêtre de Snippet Pixie (action par défaut)"
 
-#: src/Application.vala:1172
+#: src/Application.vala:1205
 msgid "Start with no window"
 msgstr "Lancer sans fenêtre"
 
-#: src/Application.vala:1173
+#: src/Application.vala:1206
 msgid "Fully quit the application, including the background process"
 msgstr ""
 "Quitter complétement l'application, ainsi que le processus en arrière-plan"
 
-#: src/Application.vala:1174
+#: src/Application.vala:1207
 msgid ""
 "Turn auto start of Snippet Pixie on login, on, off, or show status of setting"
 msgstr ""
 "Activer le démarrage automatique de Snippet Pixie lors de la connexion, "
 "activer, désactiver ou afficher l'état des paramètres"
 
-#: src/Application.vala:1175
+#: src/Application.vala:1208
 msgid ""
 "Shows status of the application, exits with status 0 if running, 1 if not"
 msgstr ""
 "Affiche l'état de l'application, quitte avec le statut 0 si en cours "
 "d'exécution, 1 sinon"
 
-#: src/Application.vala:1176
+#: src/Application.vala:1209
 msgid "Export snippets to file"
 msgstr "Exporter les raccourcis vers un fichier"
 
-#: src/Application.vala:1177
+#: src/Application.vala:1210
 msgid ""
 "Import snippets from file, skips snippets where abbreviation already exists"
 msgstr ""
 "Importer des raccourcis à partir d'un fichier, ignore les raccourcis où "
 "l'abréviation existe déjà"
 
-#: src/Application.vala:1177
+#: src/Application.vala:1210
 msgid "filename"
 msgstr "Nom du fichier"
 
-#: src/Application.vala:1178
+#: src/Application.vala:1211
 msgid ""
 "If used in conjunction with import, existing snippets with same abbreviation "
 "are updated"
@@ -307,44 +311,44 @@ msgstr ""
 "S'ils sont utilisés conjointement avec l'importation, les raccourcis "
 "existants avec la même abréviation sont mis à jour"
 
-#: src/Application.vala:1179
+#: src/Application.vala:1212
 msgid "Display version number"
 msgstr "Afficher le numéro de version"
 
-#: src/Application.vala:1180
+#: src/Application.vala:1213
 msgid "Display this help"
 msgstr "Afficher cette aide"
 
-#: src/Application.vala:1199
+#: src/Application.vala:1232
 #, c-format
 msgid "error: %s\n"
 msgstr "Erreur : %s\n"
 
-#: src/Application.vala:1200
+#: src/Application.vala:1233
 #, c-format
 msgid "Run '%s --help' to see a full list of available command line options.\n"
 msgstr ""
 "Exécutez « %s --help » pour visualiser la liste complète des options "
 "disponibles en ligne de commande.\n"
 
-#: src/Application.vala:1216
+#: src/Application.vala:1249
 msgid "Quitting…\n"
 msgstr "Fermeture…\n"
 
-#: src/Application.vala:1224
+#: src/Application.vala:1257
 msgid "Running.\n"
 msgstr "En cours d'exécution.\n"
 
-#: src/Application.vala:1227
+#: src/Application.vala:1260
 msgid "Not Running.\n"
 msgstr "Pas en cours d'exécution.\n"
 
-#: src/Application.vala:1249
+#: src/Application.vala:1285
 #, c-format
 msgid "Invalid autostart value \"%s\".\n"
 msgstr "Valeur de démarrage automatique invalide « %s ».\n"
 
-#: src/Application.vala:1295
+#: src/Application.vala:1330
 msgid "Cannot run without threads.\n"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.bytepixie.snippetpixie\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-05 21:56+0000\n"
+"POT-Creation-Date: 2021-08-19 09:43+0100\n"
 "PO-Revision-Date: 2020-11-06 17:24+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language-Team: \n"
@@ -31,45 +31,49 @@ msgid "Add Snippet"
 msgstr "Knipsel toevoegen"
 
 #: src/Widgets/MainWindowHeader.vala:45
-msgid "Search Snippets"
-msgstr "Knipsels doorzoeken"
+msgid "Auto start on login"
+msgstr ""
 
 #: src/Widgets/MainWindowHeader.vala:48
-#: src/Windows/SearchAndPasteWindow.vala:56
-msgid "Search Snippets…"
-msgstr "Knipsels doorzoeken…"
-
-#: src/Widgets/MainWindowHeader.vala:66
 msgid "Auto expand Snippets"
 msgstr "Knipsels automatisch aanvullen"
 
-#: src/Widgets/MainWindowHeader.vala:69 src/Widgets/MainWindowHeader.vala:103
+#: src/Widgets/MainWindowHeader.vala:51 src/Widgets/MainWindowHeader.vala:86
 msgid "Shortcut"
 msgstr "Sneltoets"
 
-#: src/Widgets/MainWindowHeader.vala:72 src/Widgets/MainWindowHeader.vala:76
+#: src/Widgets/MainWindowHeader.vala:54 src/Widgets/MainWindowHeader.vala:58
 msgid "Import Snippets…"
 msgstr "Knipsels importeren…"
 
-#: src/Widgets/MainWindowHeader.vala:79 src/Widgets/MainWindowHeader.vala:83
+#: src/Widgets/MainWindowHeader.vala:61 src/Widgets/MainWindowHeader.vala:65
 msgid "Export Snippets…"
 msgstr "Knipsels exporteren…"
 
-#: src/Widgets/MainWindowHeader.vala:86
+#: src/Widgets/MainWindowHeader.vala:68
 msgid "About…"
 msgstr "Over…"
 
-#: src/Widgets/MainWindowHeader.vala:108
+#: src/Widgets/MainWindowHeader.vala:91
 msgid "Search selected text"
 msgstr "Zoeken naar geselecteerde tekst"
 
-#: src/Widgets/MainWindowHeader.vala:111
+#: src/Widgets/MainWindowHeader.vala:94
 msgid "Focus search box"
 msgstr "Zoekvak focussen"
 
-#: src/Widgets/MainWindowHeader.vala:125
+#: src/Widgets/MainWindowHeader.vala:108
 msgid "Shortcut:"
 msgstr "Sneltoets:"
+
+#: src/Widgets/MainWindowHeader.vala:154
+msgid "Search Snippets"
+msgstr "Knipsels doorzoeken"
+
+#: src/Widgets/MainWindowHeader.vala:157
+#: src/Windows/SearchAndPasteWindow.vala:56
+msgid "Search Snippets…"
+msgstr "Knipsels doorzoeken…"
 
 #: src/Widgets/ViewStack.vala:54
 msgid "Abbreviation"
@@ -100,7 +104,7 @@ msgstr "Je hebt nog geen knipsels."
 msgid "Create your first snippet."
 msgstr "Maak je eerste knipsel."
 
-#: src/Widgets/WelcomeView.vala:24 src/Windows/MainWindow.vala:154
+#: src/Widgets/WelcomeView.vala:24 src/Windows/MainWindow.vala:155
 msgid "Import Snippets"
 msgstr "Knipsels importeren"
 
@@ -116,15 +120,15 @@ msgstr "Snelstartgids"
 msgid "Learn the basics of how to use Snippet Pixie."
 msgstr "Leer hoe je met Snippet Pixie werkt."
 
-#: src/Windows/MainWindow.vala:154
+#: src/Windows/MainWindow.vala:155
 msgid "Import"
 msgstr "Importeren"
 
-#: src/Windows/MainWindow.vala:161
+#: src/Windows/MainWindow.vala:162
 msgid "Overwrite Duplicate Snippets?"
 msgstr "Duplicaten overschrijven?"
 
-#: src/Windows/MainWindow.vala:161
+#: src/Windows/MainWindow.vala:162
 msgid ""
 "If any of the snippet abbreviations about to be imported already exist, do "
 "you want to skip importing them or update the existing snippet?"
@@ -132,58 +136,58 @@ msgstr ""
 "Als de te importeren knipsels al bestaan, wil je ze dan overslaan of de "
 "bestaande knipsels bijwerken?"
 
-#: src/Windows/MainWindow.vala:162
+#: src/Windows/MainWindow.vala:163
 msgid "Update Existing"
 msgstr "Bestaande bijwerken"
 
-#: src/Windows/MainWindow.vala:163
+#: src/Windows/MainWindow.vala:164
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: src/Windows/MainWindow.vala:164
+#: src/Windows/MainWindow.vala:165
 msgid "Skip Duplicates"
 msgstr "Duplicaten overslaan"
 
-#: src/Windows/MainWindow.vala:191
+#: src/Windows/MainWindow.vala:192
 msgid "Imported Snippets"
 msgstr "Geïmporteerde knipsels"
 
-#: src/Windows/MainWindow.vala:191
+#: src/Windows/MainWindow.vala:192
 msgid "Your snippets were successfully imported."
 msgstr "Je knipsels zijn geïmporteerd."
 
-#: src/Windows/MainWindow.vala:195
+#: src/Windows/MainWindow.vala:196
 msgid "Failed to import selected file"
 msgstr "Importeren mislukt"
 
-#: src/Windows/MainWindow.vala:195
+#: src/Windows/MainWindow.vala:196
 msgid ""
 "Snippet Pixie can currently only import the JSON format files that it also "
 "exports."
 msgstr ""
 "Snippet Pixie kan alleen eerder geëxporteerde json-bestanden importeren."
 
-#: src/Windows/MainWindow.vala:203
+#: src/Windows/MainWindow.vala:204
 msgid "Export Snippets"
 msgstr "Knipsels exporteren"
 
-#: src/Windows/MainWindow.vala:211
+#: src/Windows/MainWindow.vala:212
 msgid "Exported Snippets"
 msgstr "Geëxporteerde knipsels"
 
-#: src/Windows/MainWindow.vala:211
+#: src/Windows/MainWindow.vala:212
 msgid "Your snippets were successfully exported."
 msgstr "Je knipsels zijn geëxporteerd."
 
-#: src/Windows/MainWindow.vala:215
+#: src/Windows/MainWindow.vala:216
 msgid "Failed to export to file"
 msgstr "Exporteren mislukt"
 
-#: src/Windows/MainWindow.vala:215
+#: src/Windows/MainWindow.vala:216
 msgid "Something went wrong, sorry."
 msgstr "Er is iets misgegaan."
 
-#: src/Windows/MainWindow.vala:233
+#: src/Windows/MainWindow.vala:236
 msgid ""
 "@NathanBnm https://github.com/NathanBnm/\n"
 "            @Vistaus https://github.com/Vistaus/"
@@ -191,7 +195,7 @@ msgstr ""
 "@NathanBnm https://github.com/NathanBnm/\n"
 "            @Vistaus https://github.com/Vistaus/"
 
-#: src/Windows/MainWindow.vala:237
+#: src/Windows/MainWindow.vala:240
 msgid "Copyright © Byte Pixie Limited"
 msgstr "Copyright © Byte Pixie Limited"
 
@@ -199,19 +203,19 @@ msgstr "Copyright © Byte Pixie Limited"
 msgid "Please add some snippets!"
 msgstr "Voeg knipsels toe!"
 
-#: src/Application.vala:640
+#: src/Application.vala:652
 msgid "snippet"
 msgstr "knipsel"
 
-#: src/Application.vala:682 src/Application.vala:800
+#: src/Application.vala:694 src/Application.vala:812
 msgid "date"
 msgstr "datum"
 
-#: src/Application.vala:682 src/Application.vala:804
+#: src/Application.vala:694 src/Application.vala:816
 msgid "time"
 msgstr "tijd"
 
-#: src/Application.vala:716
+#: src/Application.vala:728
 #, c-format
 msgid ""
 "Date adjustment does not seem to have a positive or negative integer in "
@@ -220,7 +224,7 @@ msgstr ""
 "De datumaanpassing lijkt geen positief of negatief geheel getal te bevatten "
 "in plaatshouder '%1$s'."
 
-#: src/Application.vala:731
+#: src/Application.vala:743
 #, c-format
 msgid ""
 "Date adjustment number %1$d does not seem to start with a positive or "
@@ -229,7 +233,7 @@ msgstr ""
 "De datumaanpassing %1$d lijkt niet te beginnen met een positief of negatief "
 "geheel in plaatshouder '%2$s'."
 
-#: src/Application.vala:762
+#: src/Application.vala:774
 #, c-format
 msgid ""
 "Date adjustment number %1$d does not seem to end with either 'Y', 'M', 'W', "
@@ -238,105 +242,105 @@ msgstr ""
 "De datumaanpassing %1$d lijkt niet te eindigen op 'Y', 'M', 'W', 'D', 'h', "
 "'m' of 's' in plaatshouder '%2$s'."
 
-#: src/Application.vala:770 src/Application.vala:783
+#: src/Application.vala:782 src/Application.vala:795
 #, c-format
 msgid "Oops, date format '%1$s' could not be parsed."
 msgstr "De datumopmaak '%1$s' kan niet worden verwerkt."
 
-#: src/Application.vala:812
+#: src/Application.vala:824
 msgid "clipboard"
 msgstr "klembord"
 
-#: src/Application.vala:848
+#: src/Application.vala:860
 msgid "cursor"
 msgstr "cursor"
 
-#: src/Application.vala:1170
+#: src/Application.vala:1203
 msgid "Show Snippet Pixie's window (default action)"
 msgstr "Toon Snippet Pixie's venster (standaardactie)"
 
-#: src/Application.vala:1171
+#: src/Application.vala:1204
 msgid "Show Snippet Pixie's quick search and paste window"
 msgstr "Toon Snippet Pixie's snelzoekvak-en-plakvenster"
 
-#: src/Application.vala:1172
+#: src/Application.vala:1205
 msgid "Start with no window"
 msgstr "Geminimaliseerd opstarten"
 
-#: src/Application.vala:1173
+#: src/Application.vala:1206
 msgid "Fully quit the application, including the background process"
 msgstr "Sluit de toepassing volledig af, inclusief het achtergrondproces"
 
-#: src/Application.vala:1174
+#: src/Application.vala:1207
 msgid ""
 "Turn auto start of Snippet Pixie on login, on, off, or show status of setting"
 msgstr ""
 "Start Snippet Pixie automatisch op of toon de status van deze instelling"
 
-#: src/Application.vala:1175
+#: src/Application.vala:1208
 msgid ""
 "Shows status of the application, exits with status 0 if running, 1 if not"
 msgstr ""
 "Toon de toepassingsstatus, sluit af met status 0 (indien actief) of (indien "
 "niet actief)"
 
-#: src/Application.vala:1176
+#: src/Application.vala:1209
 msgid "Export snippets to file"
 msgstr "Knipsels exporteren naar bestand"
 
-#: src/Application.vala:1177
+#: src/Application.vala:1210
 msgid ""
 "Import snippets from file, skips snippets where abbreviation already exists"
 msgstr "Importeer knipsels uit een bestand en sla bestaande knipsels over"
 
-#: src/Application.vala:1177
+#: src/Application.vala:1210
 msgid "filename"
 msgstr "bestandsnaam"
 
-#: src/Application.vala:1178
+#: src/Application.vala:1211
 msgid ""
 "If used in conjunction with import, existing snippets with same abbreviation "
 "are updated"
 msgstr "Gebruik tezamen met importeren om bestaande knipsels ook bij te werken"
 
-#: src/Application.vala:1179
+#: src/Application.vala:1212
 msgid "Display version number"
 msgstr "Toon het versienummer"
 
-#: src/Application.vala:1180
+#: src/Application.vala:1213
 msgid "Display this help"
 msgstr "Toon deze hulp"
 
-#: src/Application.vala:1199
+#: src/Application.vala:1232
 #, c-format
 msgid "error: %s\n"
 msgstr "fout: %s\n"
 
-#: src/Application.vala:1200
+#: src/Application.vala:1233
 #, c-format
 msgid "Run '%s --help' to see a full list of available command line options.\n"
 msgstr ""
 "Voer '%s --help' uit om een volledige lijst met opdrachtregelopties te "
 "tonen.\n"
 
-#: src/Application.vala:1216
+#: src/Application.vala:1249
 msgid "Quitting…\n"
 msgstr "Bezig met afsluiten…\n"
 
-#: src/Application.vala:1224
+#: src/Application.vala:1257
 msgid "Running.\n"
 msgstr "Actief.\n"
 
-#: src/Application.vala:1227
+#: src/Application.vala:1260
 msgid "Not Running.\n"
 msgstr "Niet actief.\n"
 
-#: src/Application.vala:1249
+#: src/Application.vala:1285
 #, c-format
 msgid "Invalid autostart value \"%s\".\n"
 msgstr "Ongeldige automatisch opstarten-waarde \"%s\".\n"
 
-#: src/Application.vala:1295
+#: src/Application.vala:1330
 msgid "Cannot run without threads.\n"
 msgstr "Kan niet worden uitgevoerd zonder threads.\n"
 

--- a/src/Widgets/MainWindowHeader.vala
+++ b/src/Widgets/MainWindowHeader.vala
@@ -41,6 +41,9 @@ public class SnippetPixie.MainWindowHeader : Gtk.HeaderBar {
         // redo_button.tooltip_text = _("Redo last undo");
 
         // Main menu.
+        var autostart_menuitem = new Gtk.ModelButton ();
+        autostart_menuitem.text = _("Auto start on login");
+        autostart_menuitem.action_name = MainWindow.ACTION_PREFIX + "autostart";
         var auto_expand_menuitem = new Gtk.ModelButton ();
         auto_expand_menuitem.text = _("Auto expand Snippets");
         auto_expand_menuitem.action_name = MainWindow.ACTION_PREFIX + "auto-expand";
@@ -68,6 +71,7 @@ public class SnippetPixie.MainWindowHeader : Gtk.HeaderBar {
         var main_menu = new Gtk.Grid ();
         main_menu.margin_top = main_menu.margin_bottom = 3;
         main_menu.orientation = Gtk.Orientation.VERTICAL;
+        main_menu.add (autostart_menuitem);
         main_menu.add (auto_expand_menuitem);
         main_menu.add (shortcut_sub_menuitem);
         main_menu.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));

--- a/src/Windows/MainWindow.vala
+++ b/src/Windows/MainWindow.vala
@@ -71,6 +71,7 @@ public class SnippetPixie.MainWindow : Gtk.ApplicationWindow {
 
         actions = new SimpleActionGroup ();
         actions.add_action_entries (action_entries, this);
+        actions.add_action (settings.create_action ("autostart"));
         actions.add_action (settings.create_action ("auto-expand"));
         actions.add_action (settings.create_action ("search-selected-text"));
         actions.add_action (settings.create_action ("focus-search"));


### PR DESCRIPTION
Resolves #95 

The menu now has an "Auto start on login" entry that controls whether Snippet Pixie should be started in the background when you log in.

This new setting is needed as some desktop environments do not allow you to manage the desktop files that are placed in `~/.config/autostart/`, or do not properly handle the `X-GNOME-Autostart-enabled` entry it has.

This additional setting is also very useful for the Snap package version of Snippet Pixie as without this change it is currently not possible to control autostart due to the way snap autostart relies purely on the existence or not of the autostart desktop file within the snap's own data directory.